### PR TITLE
fix(hwpx): parse tables nested inside <hp:run> elements

### DIFF
--- a/src/hwpx/parser.ts
+++ b/src/hwpx/parser.ts
@@ -615,6 +615,9 @@ function walkParagraphChildren(
       } else {
         tableCtx = tableStack.length > 0 ? tableStack.pop()! : null
       }
+    } else if (localTag === "run") {
+      // hp:run 안에 hp:tbl이 중첩된 구조 처리 (일부 HWPX 파일)
+      tableCtx = walkParagraphChildren(el, blocks, tableCtx, tableStack, styleMap, warnings, sectionNum)
     } else if (localTag === "pic" || localTag === "shape" || localTag === "drawingObject") {
       if (warnings && sectionNum) {
         warnings.push({ page: sectionNum, message: `스킵된 요소: ${localTag}`, code: "SKIPPED_IMAGE" })


### PR DESCRIPTION
## Problem

Some HWPX files structure tables as `<hp:p> → <hp:run> → <hp:tbl>` instead of placing `<hp:tbl>` as a direct child of `<hp:p>`.

`walkParagraphChildren` only iterated over direct children of `<hp:p>`, so any `<hp:tbl>` wrapped inside a `<hp:run>` was silently skipped — resulting in **0 table blocks** parsed despite multiple `<hp:tbl>` elements present in the XML.

## Fix

Recurse into `<run>` elements within `walkParagraphChildren` so that nested tables are discovered and processed correctly.

```typescript
} else if (localTag === "run") {
  // handle hp:tbl nested inside hp:run (seen in some HWPX files)
  tableCtx = walkParagraphChildren(el, blocks, tableCtx, tableStack, styleMap, warnings, sectionNum)
}
```

## Verification

Tested on a real-world HWPX document with complex tables:

| | Before | After |
|---|---|---|
| Table blocks parsed | 0 | 138 |
| `<hp:tbl>` in XML | 144 | 144 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)