### PR TITLE
fix(table): 헤더만 있는 테이블에 빈 데이터 행 추가

### DIFF
--- a/src/table/builder.ts
+++ b/src/table/builder.ts
@@ -74,7 +74,7 @@ export function buildTable(rows: CellContext[][]): IRTable {
     }
   }
 
-  return { rows: numRows, cols: maxCols, cells: grid, hasHeader: numRows > 1 }
+  return { rows: numRows, cols: maxCols, cells: grid, hasHeader: numRows >= 1 }
 }
 
 export function convertTableToText(rows: CellContext[][]): string {
@@ -224,6 +224,11 @@ function tableToMarkdown(table: IRTable): string {
   }
 
   if (uniqueRows.length === 0) return ""
+
+  // 헤더만 있고 데이터 행이 없는 경우, 빈 데이터 행 추가
+  if (uniqueRows.length === 1) {
+    uniqueRows.push(Array(numCols).fill(""))
+  }
 
   const md: string[] = []
   md.push("| " + uniqueRows[0].join(" | ") + " |")

--- a/tests/table-builder.test.ts
+++ b/tests/table-builder.test.ts
@@ -47,12 +47,12 @@ describe("buildTable", () => {
     assert.equal(table.cols, 0)
   })
 
-  it("1행 테이블의 hasHeader는 false", () => {
+  it("1행 테이블의 hasHeader는 true", () => {
     const rows: CellContext[][] = [
       [{ text: "A", colSpan: 1, rowSpan: 1 }],
     ]
     const table = buildTable(rows)
-    assert.equal(table.hasHeader, false)
+    assert.equal(table.hasHeader, true)
   })
 })
 
@@ -90,6 +90,22 @@ describe("blocksToMarkdown", () => {
     ]
     const md = blocksToMarkdown(blocks)
     assert.ok(md.includes("*(제10조제2항 관련)*"))
+  })
+
+  it("헤더만 있는 테이블은 빈 데이터 행 추가", () => {
+    const blocks: IRBlock[] = [
+      {
+        type: "table",
+        table: buildTable([
+          [{ text: "이름", colSpan: 1, rowSpan: 1 }, { text: "나이", colSpan: 1, rowSpan: 1 }],
+        ])
+      },
+    ]
+    const md = blocksToMarkdown(blocks)
+    assert.ok(md.includes("| 이름 | 나이 |"))
+    assert.ok(md.includes("| --- | --- |"))
+    // 빈 데이터 행이 추가되어야 함
+    assert.ok(md.includes("|  |  |"))
   })
 
   it("테이블 블록을 마크다운 테이블로 변환", () => {


### PR DESCRIPTION
## 요약

- 헤더 행만 있고 데이터 행이 없는 테이블에서, 마크다운 출력에 빈 데이터 행을 추가하도록 수정
- `buildTable()`의 `hasHeader` 조건을 `numRows >= 1`로 변경하여 1행 테이블도 헤더로 인식
- 헤더만 있는 테이블에 대한 테스트 케이스 추가

## 변경 내용

### `src/table/builder.ts`
- `tableToMarkdown()`: `uniqueRows.length === 1`일 때 빈 데이터 행(`Array(numCols).fill("")`)을 추가
- `buildTable()`: `hasHeader: numRows > 1` → `hasHeader: numRows >= 1`

### `tests/table-builder.test.ts`
- 헤더만 있는 테이블이 빈 데이터 행과 함께 렌더링되는지 검증하는 테스트 추가
- 기존 `hasHeader` 테스트를 새 동작에 맞게 수정

Closes #3