### PR TITLE
fix(table): colSpan 병합 셀 내용 복제로 정보 보존

### DIFF
--- a/src/table/builder.ts
+++ b/src/table/builder.ts
@@ -205,11 +205,16 @@ function tableToMarkdown(table: IRTable): string {
       const cell = cells[r][c]
       display[r][c] = cell.text.replace(/\n/g, "<br>")
 
+      // colSpan: 병합된 열에 셀 내용 복제 (정보 보존)
+      // rowSpan: 빈 칸으로 유지 (수직 반복 방지)
       for (let dr = 0; dr < cell.rowSpan; dr++) {
         for (let dc = 0; dc < cell.colSpan; dc++) {
           if (dr === 0 && dc === 0) continue
           if (r + dr < numRows && c + dc < numCols) {
             skip.add(`${r + dr},${c + dc}`)
+            if (dr === 0) {
+              display[r][c + dc] = cell.text.replace(/\n/g, "<br>")
+            }
           }
         }
       }

--- a/tests/table-builder.test.ts
+++ b/tests/table-builder.test.ts
@@ -92,6 +92,37 @@ describe("blocksToMarkdown", () => {
     assert.ok(md.includes("*(제10조제2항 관련)*"))
   })
 
+  it("colSpan 병합 셀은 내용을 복제하여 정보 보존", () => {
+    const blocks: IRBlock[] = [
+      {
+        type: "table",
+        table: buildTable([
+          [{ text: "병합셀", colSpan: 2, rowSpan: 1 }],
+          [{ text: "값1", colSpan: 1, rowSpan: 1 }, { text: "값2", colSpan: 1, rowSpan: 1 }],
+        ])
+      },
+    ]
+    const md = blocksToMarkdown(blocks)
+    assert.ok(md.includes("| 병합셀 | 병합셀 |"), "colSpan 병합 셀 내용이 복제되어야 함")
+    assert.ok(md.includes("| 값1 | 값2 |"))
+  })
+
+  it("rowSpan 병합 셀은 빈 칸으로 유지", () => {
+    const blocks: IRBlock[] = [
+      {
+        type: "table",
+        table: buildTable([
+          [{ text: "헤더1", colSpan: 1, rowSpan: 1 }, { text: "헤더2", colSpan: 1, rowSpan: 1 }],
+          [{ text: "행병합", colSpan: 1, rowSpan: 2 }, { text: "값1", colSpan: 1, rowSpan: 1 }],
+          [{ text: "값2", colSpan: 1, rowSpan: 1 }],
+        ])
+      },
+    ]
+    const md = blocksToMarkdown(blocks)
+    assert.ok(md.includes("| 행병합 | 값1 |"), "rowSpan 원본 셀은 내용 표시")
+    assert.ok(md.includes("|  | 값2 |"), "rowSpan 병합 위치는 빈 칸")
+  })
+
   it("테이블 블록을 마크다운 테이블로 변환", () => {
     const blocks: IRBlock[] = [
       {


### PR DESCRIPTION
## Summary
- colSpan 병합 셀이 마크다운 변환 시 빈 칸으로 표시되어 정보가 유실되던 문제 수정
- 병합된 열 위치에 원본 셀 텍스트를 복제하여 마크다운에서도 정보 보존
- rowSpan은 수직 반복 노이즈 방지를 위해 빈 칸 유지

## 변경 내용
- `src/table/builder.ts`: `tableToMarkdown()` 함수에서 colSpan 병합 위치에 셀 내용 복제 로직 추가
- `tests/table-builder.test.ts`: colSpan 내용 복제 및 rowSpan 빈 칸 유지 테스트 추가

## Test plan
- [x] 기존 테스트 14개 전체 통과
- [x] colSpan 병합 셀 내용 복제 테스트 추가 및 통과
- [x] rowSpan 병합 셀 빈 칸 유지 테스트 추가 및 통과
- [x] `npm run build` 정상 빌드 확인

Closes #1