### PR TITLE
fix: 조용히 무시되던 에러 핸들링 개선

### DIFF
--- a/src/ocr/provider.ts
+++ b/src/ocr/provider.ts
@@ -45,7 +45,7 @@ export async function ocrPages(
         blocks.push({ type: "paragraph", text: text.trim(), pageNumber: i })
       }
     } catch {
-      // OCR 실패한 페이지는 건너뜀
+      blocks.push({ type: "paragraph" as const, text: `[OCR 실패: 페이지 ${i}]` })
     }
   }
 

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -107,7 +107,9 @@ export async function watchDirectory(options: WatchOptions): Promise<void> {
     if (existing) clearTimeout(existing)
     pending.set(filePath, setTimeout(() => {
       pending.delete(filePath)
-      processFile(filePath).catch(() => {})
+      processFile(filePath).catch((err) => {
+        process.stderr.write(`[kordoc watch] 처리 실패: ${filePath} — ${err instanceof Error ? err.message : String(err)}\n`)
+      })
     }, DEBOUNCE_MS))
   })
 
@@ -151,7 +153,7 @@ async function sendWebhook(url: string | undefined, payload: Record<string, unkn
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ ...payload, timestamp: new Date().toISOString() }),
     })
-  } catch {
-    // webhook 실패는 조용히 무시
+  } catch (err) {
+    process.stderr.write(`[kordoc watch] webhook 전송 실패: ${err instanceof Error ? err.message : String(err)}\n`)
   }
 }


### PR DESCRIPTION
## Summary
- watch 모드에서 webhook 전송 실패 시 빈 catch 블록 대신 stderr에 에러 메시지 출력
- watch 모드에서 processFile 실패 시 `.catch(() => {})` 대신 파일명과 에러를 stderr에 출력
- OCR 실패 페이지를 조용히 건너뛰지 않고 `[OCR 실패: 페이지 N]` placeholder 블록 추가

## Test plan
- [x] `npm run build` 성공
- [x] `npm test` 173개 테스트 전체 통과
- [ ] watch 모드에서 잘못된 webhook URL로 에러 로그 출력 확인
- [ ] OCR 실패 시 placeholder 블록이 결과에 포함되는지 확인