### PR TITLE
fix(security): ReDoS 방지 및 IPv6 SSRF 우회 차단

### DIFF
--- a/src/form/recognize.ts
+++ b/src/form/recognize.ts
@@ -108,7 +108,9 @@ function extractInlineFields(text: string): FormField[] {
   // "라벨: 값" 또는 "라벨 : 값" 패턴
   const pattern = /([가-힣A-Za-z]{2,10})\s*[:：]\s*([^\n,;]{1,100})/g
   let match
-  while ((match = pattern.exec(text)) !== null) {
+  let iterations = 0
+  const MAX_FORM_MATCHES = 1000
+  while ((match = pattern.exec(text)) !== null && ++iterations < MAX_FORM_MATCHES) {
     const label = match[1].trim()
     const value = match[2].trim()
     if (value) {

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -130,6 +130,9 @@ function validateWebhookUrl(url: string): void {
   if (
     hostname === "localhost" ||
     hostname === "[::1]" ||
+    // IPv6 loopback 변형 차단
+    hostname === "[0:0:0:0:0:0:0:1]" ||
+    hostname === "[0000:0000:0000:0000:0000:0000:0000:0001]" ||
     hostname.startsWith("127.") ||
     hostname.startsWith("10.") ||
     hostname.startsWith("192.168.") ||


### PR DESCRIPTION
## Summary
- **ReDoS 방지**: `src/form/recognize.ts`의 regex exec 루프에 최대 1000회 반복 제한 추가하여 악성 입력에 의한 서비스 거부 방지
- **IPv6 SSRF 우회 차단**: `src/watch.ts`의 webhook URL 검증에 IPv6 loopback 변형 주소(`[0:0:0:0:0:0:0:1]`, `[0000:0000:0000:0000:0000:0000:0000:0001]`) 차단 추가

## Test plan
- [x] `npm run build` 성공
- [x] `npm test` 전체 173개 테스트 통과