### PR TITLE
fix: 입력 검증 안전성 개선

### DIFF
--- a/src/hwpx/parser.ts
+++ b/src/hwpx/parser.ts
@@ -99,7 +99,12 @@ function parseCharProperties(doc: Document, map: Map<string, HwpxCharProperty>):
 
       // height 속성 (centi-pt 단위)
       const height = el.getAttribute("height")
-      if (height) prop.fontSize = parseInt(height, 10) / 100
+      if (height) {
+        const parsedHeight = parseInt(height, 10)
+        if (!isNaN(parsedHeight) && parsedHeight > 0) {
+          prop.fontSize = parsedHeight / 100
+        }
+      }
 
       // bold/italic
       const bold = el.getAttribute("bold")
@@ -282,7 +287,7 @@ async function extractImagesFromZip(
         decompressed.total += data.length
         if (decompressed.total > MAX_DECOMPRESS_SIZE) throw new KordocError("ZIP 압축 해제 크기 초과 (ZIP bomb 의심)")
 
-        const ext = ref.includes(".") ? ref.split(".").pop()! : "png"
+        const ext = ref.includes(".") ? (ref.split(".").pop() || "png") : "png"
         const mimeType = imageExtToMime(ext)
         imageIndex++
         const filename = `image_${String(imageIndex).padStart(3, "0")}.${mimeToExt(mimeType)}`
@@ -699,8 +704,10 @@ function walkSection(
 
       case "cellSpan":
         if (tableCtx?.cell) {
-          const cs = parseInt(el.getAttribute("colSpan") || "1", 10)
-          const rs = parseInt(el.getAttribute("rowSpan") || "1", 10)
+          const rawCs = parseInt(el.getAttribute("colSpan") || "1", 10)
+          const cs = isNaN(rawCs) ? 1 : rawCs
+          const rawRs = parseInt(el.getAttribute("rowSpan") || "1", 10)
+          const rs = isNaN(rawRs) ? 1 : rawRs
           tableCtx.cell.colSpan = clampSpan(cs, MAX_COLS)
           tableCtx.cell.rowSpan = clampSpan(rs, MAX_ROWS)
         }

--- a/src/pdf/parser.ts
+++ b/src/pdf/parser.ts
@@ -32,12 +32,11 @@ async function loadPdfWithTimeout(buffer: ArrayBuffer) {
     disableFontFace: true,
     isEvalSupported: false,
   })
-  return Promise.race([
-    loadingTask.promise,
-    new Promise<never>((_, reject) =>
-      setTimeout(() => { loadingTask.destroy(); reject(new KordocError("PDF 로딩 타임아웃 (30초 초과)")) }, PDF_LOAD_TIMEOUT_MS)
-    ),
-  ])
+  let timeoutId: ReturnType<typeof setTimeout>
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => { loadingTask.destroy(); reject(new KordocError("PDF 로딩 타임아웃 (30초 초과)")) }, PDF_LOAD_TIMEOUT_MS)
+  })
+  return Promise.race([loadingTask.promise, timeoutPromise]).finally(() => clearTimeout(timeoutId))
 }
 
 interface PdfTextItem {


### PR DESCRIPTION
## 요약

코드 리뷰에서 발견된 입력 검증 관련 4건의 안전성 이슈를 수정합니다.

- **`.pop()!` 비안전 단언 제거**: `ref.split(".").pop()!`를 fallback 기본값(`"png"`)으로 교체
- **colSpan/rowSpan NaN 가드 추가**: `parseInt` 결과가 `NaN`일 경우 기본값 `1`로 처리
- **폰트 크기 파싱 검증 강화**: `NaN` 및 음수/0 값 필터링 추가
- **PDF 타임아웃 타이머 리소스 누수 방지**: `Promise.race`에 `.finally(() => clearTimeout(...))`를 추가하여 정상 완료 시에도 타이머 정리

## 테스트 계획

- [x] `npm run build` 컴파일 성공 확인
- [x] `npm test` 전체 173건 통과 확인