### PR TITLE
chore: CI 구성과 npm 퍼블리시 워크플로 업데이트

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Test and Build
 
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [18, 20, 22, 24]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
       matrix:
         node-version: [18, 20, 22, 24]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,29 @@
+name: 'Publish to npm'
+on:
+  release:
+    types: [published]
+
+jobs:
+  release:
+    name: Publish stable release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Set up NodeJS LTS
+        uses: actions/setup-node@v6
+        with:
+          node-version: 'lts/*'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Update npm package manager
+        run: npm install -g npm@latest
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Install dependencies
+        run: npm i
+      - name: Build
+        run: npm run build
+      - name : Publish to npm
+        run: npm publish --access public
+    if: ${{ github.event_name == 'release' && github.event.release.prerelease == false }}


### PR DESCRIPTION
1. 최신 Node.js LTS 버전인 24를 테스트 워크플로 (`ci.yml`)에 추가했습니다.
2. `actions/checkout`와 `actions/setup-node`의 최신 버전인 `v6`를 사용하도록 변경했습니다.
3. [npmjs.com 의 trusted publisher](https://docs.npmjs.com/trusted-publishers) 를 사용하여 supply chain attack (공급망 공격)을 완화하여 https://github.com/axios/axios/issues/10604 와 https://github.com/axios/axios/issues/10636 같은 사례가 부분적이라도 발생하지 않도록 하였습니다.

이에 대해 궁금하신 점이 있으시면 말씀해주세요. (beta 채널 또는 build 채널 같이 prerelease도 구현할 수 있습니다)
3번 업데이트 사항에 대해 npmjs.com 에서 직접 설정하여하는게 있습니다. 한번 맨션된 문서를 읽어주십시오.