### PR TITLE
feat: mark nested table positions with [중첩 테이블] in output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kordoc",
-  "version": "2.2.4",
+  "version": "2.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kordoc",
-      "version": "2.2.4",
+      "version": "2.2.6",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.28.0",

--- a/src/hwp5/parser.ts
+++ b/src/hwp5/parser.ts
@@ -820,6 +820,7 @@ function parseCellBlock(records: HwpRecord[], startIdx: number, tableLevel: numb
   }
 
   let i = startIdx + 1
+  let hasNestedTable = false
 
   while (i < records.length) {
     const r = records[i]
@@ -830,8 +831,19 @@ function parseCellBlock(records: HwpRecord[], startIdx: number, tableLevel: numb
       const t = extractText(r.data).trim()
       if (t) texts.push(t)
     }
+
+    // 셀 내부 중첩 테이블 감지 (HWP5에서는 내용 파싱 없이 마커만 표시)
+    if (r.tagId === TAG_CTRL_HEADER && r.data.length >= 4) {
+      const ctrlId = r.data.subarray(0, 4).toString("ascii")
+      if ((ctrlId === " lbt" || ctrlId === "tbl ") && !hasNestedTable) {
+        hasNestedTable = true
+      }
+    }
+
     i++
   }
+
+  if (hasNestedTable) texts.push("[중첩 테이블]")
 
   return { cell: { text: texts.join("\n"), colSpan, rowSpan, colAddr, rowAddr } as CellContext, nextIdx: i }
 }

--- a/src/hwp5/parser.ts
+++ b/src/hwp5/parser.ts
@@ -87,6 +87,7 @@ export function parseHwp5Document(buffer: Buffer, options?: ParseOptions): Inter
   const totalTarget = pageFilter ? pageFilter.size : sections.length
 
   const blocks: IRBlock[] = []
+  const nestedTableCounter = { count: 0 }
   let totalDecompressed = 0
   let parsedSections = 0
   for (let si = 0; si < sections.length; si++) {
@@ -98,7 +99,7 @@ export function parseHwp5Document(buffer: Buffer, options?: ParseOptions): Inter
       totalDecompressed += data.length
       if (totalDecompressed > MAX_TOTAL_DECOMPRESS) throw new KordocError("총 압축 해제 크기 초과 (decompression bomb 의심)")
       const records = readRecords(data)
-      const sectionBlocks = parseSection(records, docInfo, warnings, si + 1)
+      const sectionBlocks = parseSection(records, docInfo, warnings, si + 1, nestedTableCounter)
       blocks.push(...sectionBlocks)
       parsedSections++
       options?.onProgress?.(parsedSections, totalTarget)
@@ -536,7 +537,7 @@ function extractHwp5ImagesLenient(
   return images
 }
 
-function parseSection(records: HwpRecord[], docInfo: HwpDocInfo | null, warnings: ParseWarning[], sectionNum: number): IRBlock[] {
+function parseSection(records: HwpRecord[], docInfo: HwpDocInfo | null, warnings: ParseWarning[], sectionNum: number, counter?: { count: number }): IRBlock[] {
   const blocks: IRBlock[] = []
   let i = 0
 
@@ -544,7 +545,7 @@ function parseSection(records: HwpRecord[], docInfo: HwpDocInfo | null, warnings
     const rec = records[i]
 
     if (rec.tagId === TAG_PARA_HEADER && rec.level === 0) {
-      const { paragraph, tables, nextIdx, charShapeIds, paraShapeId } = parseParagraphWithTables(records, i)
+      const { paragraph, tables, nextIdx, charShapeIds, paraShapeId } = parseParagraphWithTables(records, i, counter)
       if (paragraph) {
         const block: IRBlock = { type: "paragraph", text: paragraph, pageNumber: sectionNum }
         // CHAR_SHAPE 기반 스타일 정보 추가
@@ -570,7 +571,7 @@ function parseSection(records: HwpRecord[], docInfo: HwpDocInfo | null, warnings
     if (rec.tagId === TAG_CTRL_HEADER && rec.level <= 1 && rec.data.length >= 4) {
       const ctrlId = rec.data.subarray(0, 4).toString("ascii")
       if (ctrlId === " lbt" || ctrlId === "tbl ") {
-        const { table, nextIdx } = parseTableBlock(records, i)
+        const { table, nextIdx } = parseTableBlock(records, i, counter)
         if (table) blocks.push({ type: "table", table, pageNumber: sectionNum })
         i = nextIdx
         continue
@@ -709,7 +710,7 @@ function resolveCharStyle(charShapeIds: number[], docInfo: HwpDocInfo): InlineSt
   return (style.fontSize || style.bold || style.italic) ? style : undefined
 }
 
-function parseParagraphWithTables(records: HwpRecord[], startIdx: number) {
+function parseParagraphWithTables(records: HwpRecord[], startIdx: number, counter?: { count: number }) {
   const startLevel = records[startIdx].level
   let text = ""
   const tables: ReturnType<typeof buildTable>[] = []
@@ -740,7 +741,7 @@ function parseParagraphWithTables(records: HwpRecord[], startIdx: number) {
     if (rec.tagId === TAG_CTRL_HEADER && rec.data.length >= 4) {
       const ctrlId = rec.data.subarray(0, 4).toString("ascii")
       if (ctrlId === " lbt" || ctrlId === "tbl ") {
-        const { table, nextIdx } = parseTableBlock(records, i)
+        const { table, nextIdx } = parseTableBlock(records, i, counter)
         if (table) tables.push(table)
         i = nextIdx
         continue
@@ -753,7 +754,7 @@ function parseParagraphWithTables(records: HwpRecord[], startIdx: number) {
   return { paragraph: trimmed || null, tables, nextIdx: i, charShapeIds, paraShapeId }
 }
 
-function parseTableBlock(records: HwpRecord[], startIdx: number) {
+function parseTableBlock(records: HwpRecord[], startIdx: number, counter?: { count: number }) {
   const tableLevel = records[startIdx].level
   let i = startIdx + 1
   let rows = 0, cols = 0
@@ -770,7 +771,7 @@ function parseTableBlock(records: HwpRecord[], startIdx: number) {
     }
 
     if (rec.tagId === TAG_LIST_HEADER) {
-      const { cell, nextIdx } = parseCellBlock(records, i, tableLevel)
+      const { cell, nextIdx } = parseCellBlock(records, i, tableLevel, counter)
       if (cell) cells.push(cell)
       i = nextIdx
       continue
@@ -797,7 +798,7 @@ function parseTableBlock(records: HwpRecord[], startIdx: number) {
   return { table: buildTable(cellRows), nextIdx: i }
 }
 
-function parseCellBlock(records: HwpRecord[], startIdx: number, tableLevel: number) {
+function parseCellBlock(records: HwpRecord[], startIdx: number, tableLevel: number, counter?: { count: number }) {
   const rec = records[startIdx]
   const cellLevel = rec.level
   const texts: string[] = []
@@ -820,7 +821,6 @@ function parseCellBlock(records: HwpRecord[], startIdx: number, tableLevel: numb
   }
 
   let i = startIdx + 1
-  let hasNestedTable = false
 
   while (i < records.length) {
     const r = records[i]
@@ -833,17 +833,21 @@ function parseCellBlock(records: HwpRecord[], startIdx: number, tableLevel: numb
     }
 
     // 셀 내부 중첩 테이블 감지 (HWP5에서는 내용 파싱 없이 마커만 표시)
+    // 힌트 없음 — HWP5는 이 단계에서 중첩 테이블 내부를 파싱하지 않으므로 첫 행 추출 불가
     if (r.tagId === TAG_CTRL_HEADER && r.data.length >= 4) {
       const ctrlId = r.data.subarray(0, 4).toString("ascii")
-      if ((ctrlId === " lbt" || ctrlId === "tbl ") && !hasNestedTable) {
-        hasNestedTable = true
+      if (ctrlId === " lbt" || ctrlId === "tbl ") {
+        if (counter) {
+          counter.count++
+          texts.push(`[중첩 테이블 #${counter.count}]`)
+        } else {
+          texts.push("[중첩 테이블]")
+        }
       }
     }
 
     i++
   }
-
-  if (hasNestedTable) texts.push("[중첩 테이블]")
 
   return { cell: { text: texts.join("\n"), colSpan, rowSpan, colAddr, rowAddr } as CellContext, nextIdx: i }
 }

--- a/src/hwpx/parser.ts
+++ b/src/hwpx/parser.ts
@@ -590,17 +590,16 @@ function handleNestedTable(
   const parentTable = tableStack.pop()!
   let nestedCols = 0
   for (const r of newTable.rows) if (r.length > nestedCols) nestedCols = r.length
-  const marker = ctx.counter
-    ? makeNestedTableMarker(ctx.counter, newTable.rows)
-    : "[중첩 테이블]"
   if (newTable.rows.length >= 3 && nestedCols >= 2) {
     blocks.push({ type: "table", table: buildTable(newTable.rows), pageNumber: ctx.sectionNum })
     if (parentTable.cell) {
+      const marker = ctx.counter ? makeNestedTableMarker(ctx.counter, newTable.rows) : "[중첩 테이블]"
       parentTable.cell.text += (parentTable.cell.text ? "\n" : "") + marker
     }
   } else {
     const nestedText = convertTableToText(newTable.rows)
     if (parentTable.cell) {
+      const marker = ctx.counter ? makeNestedTableMarker(ctx.counter, newTable.rows) : "[중첩 테이블]"
       parentTable.cell.text += (parentTable.cell.text ? "\n" : "") + marker + "\n" + nestedText
     }
   }

--- a/src/hwpx/parser.ts
+++ b/src/hwpx/parser.ts
@@ -568,7 +568,7 @@ function detectHwpxHeadings(blocks: IRBlock[], styleMap: HwpxStyleMap): void {
 function makeNestedTableMarker(counter: { count: number }, rows: CellContext[][]): string {
   counter.count++
   const firstRow = rows[0] ?? []
-  const hint = firstRow.map(c => c.text.trim()).filter(Boolean).join(" | ")
+  const hint = firstRow.map(c => c.text.trim().replace(/\n/g, " ")).filter(Boolean).join(" | ")
   const hintChars = [...hint]
   const truncated = hintChars.length > 60 ? hintChars.slice(0, 60).join("") + "…" : hint
   return truncated

--- a/src/hwpx/parser.ts
+++ b/src/hwpx/parser.ts
@@ -618,10 +618,14 @@ function walkSection(
             let nestedCols = 0; for (const r of newTable.rows) if (r.length > nestedCols) nestedCols = r.length
             if (newTable.rows.length >= 3 && nestedCols >= 2) {
               blocks.push({ type: "table", table: buildTable(newTable.rows), pageNumber: sectionNum })
+              // 부모 셀에 중첩 테이블 위치 마킹 (별도 블록으로 분리됨을 표시)
+              if (parentTable.cell) {
+                parentTable.cell.text += (parentTable.cell.text ? "\n" : "") + "[중첩 테이블]"
+              }
             } else {
               const nestedText = convertTableToText(newTable.rows)
               if (parentTable.cell) {
-                parentTable.cell.text += (parentTable.cell.text ? "\n" : "") + nestedText
+                parentTable.cell.text += (parentTable.cell.text ? "\n" : "") + "[중첩 테이블]\n" + nestedText
               }
             }
             tableCtx = parentTable
@@ -743,10 +747,14 @@ function walkParagraphChildren(
             let nestedCols = 0; for (const r of newTable.rows) if (r.length > nestedCols) nestedCols = r.length
             if (newTable.rows.length >= 3 && nestedCols >= 2) {
               blocks.push({ type: "table", table: buildTable(newTable.rows), pageNumber: sectionNum })
+              // 부모 셀에 중첩 테이블 위치 마킹 (별도 블록으로 분리됨을 표시)
+              if (parentTable.cell) {
+                parentTable.cell.text += (parentTable.cell.text ? "\n" : "") + "[중첩 테이블]"
+              }
             } else {
               const nestedText = convertTableToText(newTable.rows)
               if (parentTable.cell) {
-                parentTable.cell.text += (parentTable.cell.text ? "\n" : "") + nestedText
+                parentTable.cell.text += (parentTable.cell.text ? "\n" : "") + "[중첩 테이블]\n" + nestedText
               }
             }
             tableCtx = parentTable

--- a/src/hwpx/parser.ts
+++ b/src/hwpx/parser.ts
@@ -30,6 +30,14 @@ const MAX_XML_DEPTH = 200
 
 interface TableState { rows: CellContext[][]; currentRow: CellContext[]; cell: CellContext | null }
 
+/** walk 함수들이 공유하는 파싱 컨텍스트 — 개별 optional 파라미터를 하나로 묶어 시그니처 안정화 */
+interface WalkCtx {
+  styleMap?: HwpxStyleMap
+  warnings?: ParseWarning[]
+  sectionNum?: number
+  counter?: { count: number }
+}
+
 /** xmldom DOMParser 생성 — onError 콜백으로 malformed XML 경고 수집 */
 function createXmlParser(warnings?: ParseWarning[]): DOMParser {
   return new DOMParser({
@@ -186,6 +194,7 @@ export async function parseHwpxDocument(buffer: ArrayBuffer, options?: ParseOpti
   const pageFilter = options?.pages ? parsePageRange(options.pages, sectionPaths.length) : null
   const totalTarget = pageFilter ? pageFilter.size : sectionPaths.length
   const blocks: IRBlock[] = []
+  const nestedTableCounter = { count: 0 }
   let parsedSections = 0
   for (let si = 0; si < sectionPaths.length; si++) {
     if (pageFilter && !pageFilter.has(si + 1)) continue
@@ -195,7 +204,7 @@ export async function parseHwpxDocument(buffer: ArrayBuffer, options?: ParseOpti
       const xml = await file.async("text")
       decompressed.total += xml.length * 2
       if (decompressed.total > MAX_DECOMPRESS_SIZE) throw new KordocError("ZIP 압축 해제 크기 초과 (ZIP bomb 의심)")
-      blocks.push(...parseSectionXml(xml, styleMap, warnings, si + 1))
+      blocks.push(...parseSectionXml(xml, styleMap, warnings, si + 1, nestedTableCounter))
       parsedSections++
       options?.onProgress?.(parsedSections, totalTarget)
     } catch (secErr) {
@@ -395,6 +404,7 @@ function extractFromBrokenZip(buffer: ArrayBuffer): InternalParseResult {
   let totalDecompressed = 0
   let entryCount = 0
   let sectionNum = 0
+  const nestedTableCounter = { count: 0 }
 
   while (pos < data.length - 30) {
     // PK\x03\x04 시그니처 확인 — 미매칭 시 다음 PK 시그니처까지 스캔 (중간 손상 복구)
@@ -445,7 +455,7 @@ function extractFromBrokenZip(buffer: ArrayBuffer): InternalParseResult {
       totalDecompressed += content.length * 2
       if (totalDecompressed > MAX_DECOMPRESS_SIZE) throw new KordocError("압축 해제 크기 초과")
       sectionNum++
-      blocks.push(...parseSectionXml(content, undefined, warnings, sectionNum))
+      blocks.push(...parseSectionXml(content, undefined, warnings, sectionNum, nestedTableCounter))
     } catch {
       continue
     }
@@ -554,13 +564,57 @@ function detectHwpxHeadings(blocks: IRBlock[], styleMap: HwpxStyleMap): void {
 
 // ─── 섹션 XML 파싱 ──────────────────────────────────
 
-function parseSectionXml(xml: string, styleMap?: HwpxStyleMap, warnings?: ParseWarning[], sectionNum?: number): IRBlock[] {
+/** 중첩 테이블 마커 생성 — 순번 + 첫 행 힌트(있는 경우) */
+function makeNestedTableMarker(counter: { count: number }, rows: CellContext[][]): string {
+  counter.count++
+  const firstRow = rows[0] ?? []
+  const hint = firstRow.map(c => c.text.trim()).filter(Boolean).join(" | ")
+  const hintChars = [...hint]
+  const truncated = hintChars.length > 60 ? hintChars.slice(0, 60).join("") + "…" : hint
+  return truncated
+    ? `[중첩 테이블 #${counter.count}: ${truncated}]`
+    : `[중첩 테이블 #${counter.count}]`
+}
+
+/**
+ * 중첩 테이블 처리 공통 로직 — walkSection/walkParagraphChildren 중복 제거
+ * 큰 중첩 테이블(≥3행, ≥2열)은 별도 블록으로 분리, 작은 것은 텍스트로 평탄화.
+ * 두 경우 모두 부모 셀에 마커 삽입. parentTable을 반환하여 tableCtx 갱신에 사용.
+ */
+function handleNestedTable(
+  newTable: TableState,
+  tableStack: TableState[],
+  blocks: IRBlock[],
+  ctx: WalkCtx
+): TableState {
+  const parentTable = tableStack.pop()!
+  let nestedCols = 0
+  for (const r of newTable.rows) if (r.length > nestedCols) nestedCols = r.length
+  const marker = ctx.counter
+    ? makeNestedTableMarker(ctx.counter, newTable.rows)
+    : "[중첩 테이블]"
+  if (newTable.rows.length >= 3 && nestedCols >= 2) {
+    blocks.push({ type: "table", table: buildTable(newTable.rows), pageNumber: ctx.sectionNum })
+    if (parentTable.cell) {
+      parentTable.cell.text += (parentTable.cell.text ? "\n" : "") + marker
+    }
+  } else {
+    const nestedText = convertTableToText(newTable.rows)
+    if (parentTable.cell) {
+      parentTable.cell.text += (parentTable.cell.text ? "\n" : "") + marker + "\n" + nestedText
+    }
+  }
+  return parentTable
+}
+
+function parseSectionXml(xml: string, styleMap?: HwpxStyleMap, warnings?: ParseWarning[], sectionNum?: number, counter?: { count: number }): IRBlock[] {
   const parser = createXmlParser(warnings)
   const doc = parser.parseFromString(stripDtd(xml), "text/xml")
   if (!doc.documentElement) return []
 
   const blocks: IRBlock[] = []
-  walkSection(doc.documentElement, blocks, null, [], styleMap, warnings, sectionNum)
+  const ctx: WalkCtx = { styleMap, warnings, sectionNum, counter }
+  walkSection(doc.documentElement, blocks, null, [], ctx)
   return blocks
 }
 
@@ -591,8 +645,7 @@ function extractImageRef(el: Element): string | null {
 function walkSection(
   node: Node, blocks: IRBlock[],
   tableCtx: TableState | null, tableStack: TableState[],
-  styleMap?: HwpxStyleMap, warnings?: ParseWarning[], sectionNum?: number,
-  depth: number = 0
+  ctx: WalkCtx, depth: number = 0
 ): void {
   if (depth > MAX_XML_DEPTH) return
   const children = node.childNodes
@@ -609,28 +662,13 @@ function walkSection(
       case "tbl": {
         if (tableCtx) tableStack.push(tableCtx)
         const newTable: TableState = { rows: [], currentRow: [], cell: null }
-        walkSection(el, blocks, newTable, tableStack, styleMap, warnings, sectionNum, depth + 1)
+        walkSection(el, blocks, newTable, tableStack, ctx, depth + 1)
 
         if (newTable.rows.length > 0) {
           if (tableStack.length > 0) {
-            const parentTable = tableStack.pop()!
-            // 중첩 표가 충분히 크면 (3행+, 2열+) 별도 블록으로 분리
-            let nestedCols = 0; for (const r of newTable.rows) if (r.length > nestedCols) nestedCols = r.length
-            if (newTable.rows.length >= 3 && nestedCols >= 2) {
-              blocks.push({ type: "table", table: buildTable(newTable.rows), pageNumber: sectionNum })
-              // 부모 셀에 중첩 테이블 위치 마킹 (별도 블록으로 분리됨을 표시)
-              if (parentTable.cell) {
-                parentTable.cell.text += (parentTable.cell.text ? "\n" : "") + "[중첩 테이블]"
-              }
-            } else {
-              const nestedText = convertTableToText(newTable.rows)
-              if (parentTable.cell) {
-                parentTable.cell.text += (parentTable.cell.text ? "\n" : "") + "[중첩 테이블]\n" + nestedText
-              }
-            }
-            tableCtx = parentTable
+            tableCtx = handleNestedTable(newTable, tableStack, blocks, ctx)
           } else {
-            blocks.push({ type: "table", table: buildTable(newTable.rows), pageNumber: sectionNum })
+            blocks.push({ type: "table", table: buildTable(newTable.rows), pageNumber: ctx.sectionNum })
             tableCtx = null
           }
         } else {
@@ -642,7 +680,7 @@ function walkSection(
       case "tr":
         if (tableCtx) {
           tableCtx.currentRow = []
-          walkSection(el, blocks, tableCtx, tableStack, styleMap, warnings, sectionNum, depth + 1)
+          walkSection(el, blocks, tableCtx, tableStack, ctx, depth + 1)
           if (tableCtx.currentRow.length > 0) tableCtx.rows.push(tableCtx.currentRow)
           tableCtx.currentRow = []
         }
@@ -651,7 +689,7 @@ function walkSection(
       case "tc":
         if (tableCtx) {
           tableCtx.cell = { text: "", colSpan: 1, rowSpan: 1 }
-          walkSection(el, blocks, tableCtx, tableStack, styleMap, warnings, sectionNum, depth + 1)
+          walkSection(el, blocks, tableCtx, tableStack, ctx, depth + 1)
           if (tableCtx.cell) {
             tableCtx.currentRow.push(tableCtx.cell)
             tableCtx.cell = null
@@ -680,12 +718,12 @@ function walkSection(
         break
 
       case "p": {
-        const { text, href, footnote, style } = extractParagraphInfo(el, styleMap)
+        const { text, href, footnote, style } = extractParagraphInfo(el, ctx.styleMap)
         if (text) {
           if (tableCtx?.cell) {
             tableCtx.cell.text += (tableCtx.cell.text ? "\n" : "") + text
           } else if (!tableCtx) {
-            const block: IRBlock = { type: "paragraph", text, pageNumber: sectionNum }
+            const block: IRBlock = { type: "paragraph", text, pageNumber: ctx.sectionNum }
             if (style) block.style = style
             if (href) block.href = href
             if (footnote) block.footnoteText = footnote
@@ -694,7 +732,7 @@ function walkSection(
         }
         // <p> 내부의 <tbl>만 별도 처리 — extractParagraphInfo가 이미 텍스트를 추출했으므로
         // 전체 walkSection 재귀 대신 테이블/이미지 자식만 선택적으로 처리
-        tableCtx = walkParagraphChildren(el, blocks, tableCtx, tableStack, styleMap, warnings, sectionNum, depth + 1)
+        tableCtx = walkParagraphChildren(el, blocks, tableCtx, tableStack, ctx, depth + 1)
         break
       }
 
@@ -702,15 +740,15 @@ function walkSection(
       case "pic": case "shape": case "drawingObject": {
         const imgRef = extractImageRef(el)
         if (imgRef) {
-          blocks.push({ type: "image", text: imgRef, pageNumber: sectionNum })
-        } else if (warnings && sectionNum) {
-          warnings.push({ page: sectionNum, message: `스킵된 요소: ${localTag}`, code: "SKIPPED_IMAGE" })
+          blocks.push({ type: "image", text: imgRef, pageNumber: ctx.sectionNum })
+        } else if (ctx.warnings && ctx.sectionNum) {
+          ctx.warnings.push({ page: ctx.sectionNum, message: `스킵된 요소: ${localTag}`, code: "SKIPPED_IMAGE" })
         }
         break
       }
 
       default:
-        walkSection(el, blocks, tableCtx, tableStack, styleMap, warnings, sectionNum, depth + 1)
+        walkSection(el, blocks, tableCtx, tableStack, ctx, depth + 1)
         break
     }
   }
@@ -720,8 +758,7 @@ function walkSection(
 function walkParagraphChildren(
   node: Node, blocks: IRBlock[],
   tableCtx: TableState | null, tableStack: TableState[],
-  styleMap?: HwpxStyleMap, warnings?: ParseWarning[], sectionNum?: number,
-  depth: number = 0
+  ctx: WalkCtx, depth: number = 0
 ): TableState | null {
   if (depth > MAX_XML_DEPTH) return tableCtx
   const children = node.childNodes
@@ -740,26 +777,12 @@ function walkParagraphChildren(
         // 테이블은 walkSection으로 위임
         if (tableCtx) tableStack.push(tableCtx)
         const newTable: TableState = { rows: [], currentRow: [], cell: null }
-        walkSection(el, blocks, newTable, tableStack, styleMap, warnings, sectionNum, d + 1)
+        walkSection(el, blocks, newTable, tableStack, ctx, d + 1)
         if (newTable.rows.length > 0) {
           if (tableStack.length > 0) {
-            const parentTable = tableStack.pop()!
-            let nestedCols = 0; for (const r of newTable.rows) if (r.length > nestedCols) nestedCols = r.length
-            if (newTable.rows.length >= 3 && nestedCols >= 2) {
-              blocks.push({ type: "table", table: buildTable(newTable.rows), pageNumber: sectionNum })
-              // 부모 셀에 중첩 테이블 위치 마킹 (별도 블록으로 분리됨을 표시)
-              if (parentTable.cell) {
-                parentTable.cell.text += (parentTable.cell.text ? "\n" : "") + "[중첩 테이블]"
-              }
-            } else {
-              const nestedText = convertTableToText(newTable.rows)
-              if (parentTable.cell) {
-                parentTable.cell.text += (parentTable.cell.text ? "\n" : "") + "[중첩 테이블]\n" + nestedText
-              }
-            }
-            tableCtx = parentTable
+            tableCtx = handleNestedTable(newTable, tableStack, blocks, ctx)
           } else {
-            blocks.push({ type: "table", table: buildTable(newTable.rows), pageNumber: sectionNum })
+            blocks.push({ type: "table", table: buildTable(newTable.rows), pageNumber: ctx.sectionNum })
             tableCtx = null
           }
         } else {
@@ -769,18 +792,18 @@ function walkParagraphChildren(
         // 도형/이미지 안에 drawText(글상자)가 있으면 텍스트 추출 우선
         const drawTextChild = findDescendant(el, "drawText")
         if (drawTextChild) {
-          extractDrawTextBlocks(drawTextChild, blocks, styleMap, sectionNum)
+          extractDrawTextBlocks(drawTextChild, blocks, ctx.styleMap, ctx.sectionNum)
         } else {
           const imgRef = extractImageRef(el)
           if (imgRef) {
-            blocks.push({ type: "image", text: imgRef, pageNumber: sectionNum })
-          } else if (warnings && sectionNum) {
-            warnings.push({ page: sectionNum, message: `스킵된 요소: ${localTag}`, code: "SKIPPED_IMAGE" })
+            blocks.push({ type: "image", text: imgRef, pageNumber: ctx.sectionNum })
+          } else if (ctx.warnings && ctx.sectionNum) {
+            ctx.warnings.push({ page: ctx.sectionNum, message: `스킵된 요소: ${localTag}`, code: "SKIPPED_IMAGE" })
           }
         }
       } else if (localTag === "drawText") {
         // 글상자(TextBox) 안 텍스트 추출 — <hp:p> 순회
-        extractDrawTextBlocks(el, blocks, styleMap, sectionNum)
+        extractDrawTextBlocks(el, blocks, ctx.styleMap, ctx.sectionNum)
       } else if (localTag === "r" || localTag === "run" || localTag === "ctrl"
         || localTag === "rect" || localTag === "ellipse" || localTag === "polygon"
         || localTag === "line" || localTag === "arc" || localTag === "curve"
@@ -788,7 +811,7 @@ function walkParagraphChildren(
         // <hp:run>, <hp:ctrl>, 도형 요소 내부에 테이블/이미지/글상자가 포함될 수 있음 — 재귀
         walkChildren(el, d + 1)
       } else if (localTag === "run") {
-        tableCtx = walkParagraphChildren(el, blocks, tableCtx, tableStack, styleMap, warnings, sectionNum, depth + 1)
+        tableCtx = walkParagraphChildren(el, blocks, tableCtx, tableStack, ctx, depth + 1)
       }
     }
   }


### PR DESCRIPTION
## Summary

- **HWPX**: 셀 내 중첩 테이블이 있던 위치에 `[중첩 테이블]` 마커 삽입
  - 작은 중첩 테이블 (< 3행 또는 < 2열): 평탄화된 텍스트 앞에 `[중첩 테이블]` 추가
  - 큰 중첩 테이블 (≥ 3행 + ≥ 2열): 별도 블록으로 분리되며 부모 셀에 `[중첩 테이블]` 마킹
- **HWP5**: `parseCellBlock`에서 `tbl`/`lbt` 제어 헤더를 감지해 `[중첩 테이블]` 마커 추가 (기존에는 내용이 완전히 손실됨)

## Before / After

**Before** — 중첩 테이블이 있어도 부모 셀에 아무 표시 없음:
```
| 셀 내용 | ... |
```

**After** — 중첩 테이블 위치 명시:
```
| 셀 내용<br>[중첩 테이블] | ... |
```

## Test plan

- [ ] `input.hwpx` 파싱 후 `[중첩 테이블]` 마커가 올바른 위치에 출력되는지 확인
- [ ] 중첩 테이블이 없는 일반 문서에서 마커가 불필요하게 삽입되지 않는지 확인
- [ ] HWP5 포맷에서도 동일하게 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)