### PR TITLE
feat: add HWPML 2.x parser (XML 기반 한컴 문서)

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -6,7 +6,7 @@
 [![license](https://img.shields.io/npm/l/kordoc.svg)](https://github.com/chrisryugj/kordoc/blob/main/LICENSE)
 [![node](https://img.shields.io/node/v/kordoc.svg)](https://nodejs.org)
 
-> *Parse, compare, extract, and generate Korean documents. HWP, HWPX, PDF, XLSX, DOCX — all of them.*
+> *Parse, compare, extract, and generate Korean documents. HWP, HWPX, HWPML, PDF, XLSX, DOCX — all of them.*
 
 [한국어](./README.md)
 
@@ -18,7 +18,7 @@
 
 Beyond simple text extraction, kordoc automates the **entire lifecycle of Korean government documents**.
 
-*   **📄 Any Document to Markdown**: Convert `HWP`, `HWPX`, `PDF`, `XLSX`, and `DOCX` into clean `Markdown` instantly. It produces the optimal input for LLMs to analyze and reason.
+*   **📄 Any Document to Markdown**: Convert `HWP`, `HWPX`, `HWPML`, `PDF`, `XLSX`, and `DOCX` into clean `Markdown` instantly. It produces the optimal input for LLMs to analyze and reason.
 *   **📊 Perfect Table Reconstruction**: Whether it's a borderless PDF table or a complex merged HWP table, kordoc analyzes the structure to restore accurate markdown tables.
 *   **🔍 Automatic Redline (Diff)**: Compare two documents and see exactly what changed at a glance. Supports cross-format comparison (e.g., Old HWP vs New HWPX).
 *   **📝 Markdown back to HWPX**: Convert AI-generated content back into official `HWPX` reports. No more tedious manual copy-pasting.
@@ -27,6 +27,13 @@ Beyond simple text extraction, kordoc automates the **entire lifecycle of Korean
 
 ---
 
+## What's New in v2.3.0
+
+- **📄 HWPML 2.x Parser** — Added support for XML-based HWP files (`.hwp` in XML format). Government documents that previously returned "unsupported format" are now fully parsed to Markdown. Auto-detected by XML signature (`<?xml` + `<HWPML`), separate from HWP 5.x binary files.
+
+<details>
+<summary>v2.2.4 changes</summary>
+
 ## What's New in v2.2.4
 
 - **📝 Form Auto-Fill** — Automatically fill in government form templates with values. Supports label-value cell patterns, checkboxes (`□`→`☑`), parenthesized blanks (`일반(  )통`→`일반(3)통`), and annotations (`(한자：)`→`(한자：金)`).
@@ -34,6 +41,8 @@ Beyond simple text extraction, kordoc automates the **entire lifecycle of Korean
 - **📊 HTML Table Output for Merged Cells** — Complex tables with `colspan`/`rowspan` now output as HTML `<table>` instead of GFM for accurate structure preservation.
 - **🔧 markdownToHwpx Formatting** — Greatly improved heading/bold/italic/table formatting support in reverse conversion.
 - **🤖 MCP fill_form Tool** — New MCP tool allowing AI agents to fill forms directly (8 tools total).
+
+</details>
 
 <details>
 <summary>v2.2.1 changes</summary>
@@ -304,7 +313,8 @@ npx kordoc watch ./docs --webhook https://api/hook # webhook notification
 | `parsePdf(buffer, options?)` | PDF only |
 | `parseXlsx(buffer, options?)` | XLSX only |
 | `parseDocx(buffer, options?)` | DOCX only |
-| `detectFormat(buffer)` | Returns `"hwpx" \| "hwp" \| "pdf" \| "xlsx" \| "docx" \| "unknown"` |
+| `parseHwpml(buffer, options?)` | HWPML (XML-based HWP) only |
+| `detectFormat(buffer)` | Returns `"hwpx" \| "hwp" \| "hwpml" \| "pdf" \| "xlsx" \| "docx" \| "unknown"` |
 
 ### Advanced
 
@@ -338,6 +348,7 @@ import type {
 |--------|--------|----------|
 | **HWPX** (한컴 2020+) | ZIP + XML DOM | Manifest, nested tables, merged cells, broken ZIP recovery |
 | **HWP 5.x** (한컴 Legacy) | OLE2 + CFB | Distribution decryption, corrupted CFB recovery, footnotes/hyperlinks, 21 control chars, image extraction |
+| **HWPML 2.x** (XML-based HWP) | XML DOM | HeadingType-based heading detection, merged cells, DoS protection |
 | **PDF** | pdfjs-dist | Line-based table detection, XY-Cut reading order, heading detection, hidden text filter, OCR |
 | **XLSX** (Excel) | ZIP + XML DOM | Shared strings, merged cells, multi-sheet, formula display |
 | **DOCX** (Word) | ZIP + XML DOM | Style headings, numbering, footnotes, image extraction |

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ HWP, HWPX, PDF, XLSX, DOCX — 관공서에서 쏟아지는 모든 문서를 파
 
 단순한 텍스트 추출을 넘어, **공문서 처리를 위한 모든 과정**을 자동화합니다.
 
-*   **📄 어떤 문서든 마크다운으로**: `HWP`, `HWPX`, `PDF`, `XLSX`, `DOCX` 파일을 즉시 `Markdown`으로 변환합니다. AI(LLM)가 문서를 읽고 분석하기 가장 좋은 상태로 만들어줍니다.
+*   **📄 어떤 문서든 마크다운으로**: `HWP`, `HWPX`, `HWPML`, `PDF`, `XLSX`, `DOCX` 파일을 즉시 `Markdown`으로 변환합니다. AI(LLM)가 문서를 읽고 분석하기 가장 좋은 상태로 만들어줍니다.
 *   **📊 복잡한 표(Table) 완벽 재현**: 선이 없는 PDF나 복잡하게 병합된 HWP 표도 구조를 분석하여 정확한 마크다운 테이블로 복원합니다.
 *   **🔍 신구대조표 자동 생성**: 두 문서의 차이점을 분석하여 무엇이 바뀌었는지 한눈에 보여줍니다. (HWP와 HWPX 간의 비교도 가능!)
 *   **📝 마크다운을 다시 HWPX로**: AI가 작성한 내용을 다시 보고서 양식(`HWPX`)으로 되돌려줍니다. 이제 복사-붙여넣기 노가다에서 해방되세요.
@@ -28,13 +28,20 @@ HWP, HWPX, PDF, XLSX, DOCX — 관공서에서 쏟아지는 모든 문서를 파
 
 ---
 
-## v2.2.4 변경사항
+## v2.3.0 변경사항
+
+- **📄 HWPML 2.x 파서 추가** — XML 기반 한컴 문서(`.hwp` XML 방식) 파싱 지원. `npx kordoc <file.hwp>`에서 `지원하지 않는 파일 형식` 오류가 나던 XML 기반 공문서를 이제 Markdown으로 변환할 수 있습니다. HWP 5.x 바이너리와 자동 구분(XML 시그니처 감지).
+
+<details>
+<summary>v2.2.4 변경사항</summary>
 
 - **📝 양식 자동 채우기 (Form Filler)** — 공문서 양식 템플릿에 값을 자동으로 채워넣습니다. 라벨-값 셀 패턴, 체크박스(`□`→`☑`), 괄호 빈칸(`일반(  )통`→`일반(3)통`), 어노테이션(`(한자：)`→`(한자：金)`) 지원.
 - **🏛️ HWPX 원본 서식 보존 모드** — `fillHwpx()`로 HWPX XML을 직접 조작하여 글꼴, 크기, 정렬 등 원본 서식 100% 유지한 채 값만 교체.
 - **📊 병합 셀 HTML 테이블 출력** — `colspan`/`rowspan`이 있는 복잡한 표를 GFM 대신 HTML `<table>`로 출력하여 구조 보존.
 - **🔧 markdownToHwpx 서식 강화** — 역변환 시 heading/bold/italic/table 등 서식 지원 대폭 개선.
 - **🤖 MCP fill_form 도구** — AI 에이전트가 양식을 직접 채울 수 있는 새 MCP 도구 추가 (총 8개).
+
+</details>
 
 <details>
 <summary>v2.2.1 변경사항</summary>
@@ -297,7 +304,8 @@ npx kordoc watch ./문서 --webhook https://api/hook  # 웹훅 알림
 | `parsePdf(buffer, options?)` | PDF 전용 |
 | `parseXlsx(buffer, options?)` | XLSX 전용 |
 | `parseDocx(buffer, options?)` | DOCX 전용 |
-| `detectFormat(buffer)` | `"hwpx" \| "hwp" \| "pdf" \| "xlsx" \| "docx" \| "unknown"` |
+| `parseHwpml(buffer, options?)` | HWPML (XML 기반 HWP) 전용 |
+| `detectFormat(buffer)` | `"hwpx" \| "hwp" \| "hwpml" \| "pdf" \| "xlsx" \| "docx" \| "unknown"` |
 
 ### 고급 함수
 
@@ -330,6 +338,7 @@ import type {
 |------|------|------|
 | **HWPX** (한컴 2020+) | ZIP + XML DOM | 매니페스트, 중첩 테이블, 병합 셀, 손상 ZIP 복구 |
 | **HWP 5.x** (한컴 레거시) | OLE2 + CFB | 배포용 복호화, 손상 CFB 복구, 각주/하이퍼링크, 21종 제어문자, 이미지 추출 |
+| **HWPML 2.x** (XML 기반 HWP) | XML DOM | HeadingType 기반 헤딩 감지, 병합 셀, DoS 방어 |
 | **PDF** | pdfjs-dist | 선 기반 테이블, XY-Cut 읽기 순서, 헤딩 감지, OCR |
 | **XLSX** (Excel) | ZIP + XML DOM | 공유 문자열, 병합 셀, 다중 시트, 수식 표시 |
 | **DOCX** (Word) | ZIP + XML DOM | 스타일 heading, 번호 매기기, 각주, 이미지 추출 |

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -31,12 +31,20 @@ export function isPdfFile(buffer: ArrayBuffer): boolean {
   return b[0] === 0x25 && b[1] === 0x50 && b[2] === 0x44 && b[3] === 0x46
 }
 
+/** HWPML (XML 기반 한컴 문서): <?xml ... <HWPML */
+export function isHwpmlFile(buffer: ArrayBuffer): boolean {
+  const bytes = new Uint8Array(buffer, 0, Math.min(512, buffer.byteLength))
+  const head = new TextDecoder("utf-8", { fatal: false }).decode(bytes).replace(/^\uFEFF/, "")
+  return head.trimStart().startsWith("<?xml") && head.includes("<HWPML")
+}
+
 /** 동기 포맷 감지 — ZIP은 모두 "hwpx"로 반환 (하위 호환) */
 export function detectFormat(buffer: ArrayBuffer): FileType {
   if (buffer.byteLength < 4) return "unknown"
   if (isZipFile(buffer)) return "hwpx"
   if (isOldHwpFile(buffer)) return "hwp"
   if (isPdfFile(buffer)) return "pdf"
+  if (isHwpmlFile(buffer)) return "hwpml"
   return "unknown"
 }
 

--- a/src/hwpml/parser.ts
+++ b/src/hwpml/parser.ts
@@ -243,7 +243,7 @@ function parseTable(
   const cells: CellContext[] = []
   const rowCount = parseInt(el.getAttribute("RowCount") ?? "0", 10)
   const colCount = parseInt(el.getAttribute("ColCount") ?? "0", 10)
-  if (rowCount === 0 || colCount === 0) return
+  if (isNaN(rowCount) || isNaN(colCount) || rowCount === 0 || colCount === 0) return
   if (rowCount > MAX_TABLE_ROWS || colCount > MAX_TABLE_COLS) {
     warnings.push({ message: `테이블 크기 초과 (${rowCount}x${colCount}) — 스킵`, code: "TRUNCATED_TABLE" })
     return
@@ -266,7 +266,7 @@ function parseTable(
       const rowSpan = parseInt(cellEl.getAttribute("RowSpan") ?? "1", 10)
 
       // 셀 텍스트: PARALIST > P 재귀 추출
-      const cellText = extractCellText(cellEl, paraShapeMap, sectionNum, warnings)
+      const cellText = extractCellText(cellEl)
 
       cells.push({ text: cellText, colSpan, rowSpan, colAddr, rowAddr })
     }
@@ -279,7 +279,7 @@ function parseTable(
   for (const cell of cells) {
     const r = cell.rowAddr ?? 0
     const c = cell.colAddr ?? 0
-    if (r >= rowCount || c >= colCount) continue
+    if (isNaN(r) || isNaN(c) || r >= rowCount || c >= colCount) continue
     grid[r][c] = cell
     for (let dr = 0; dr < cell.rowSpan; dr++) {
       for (let dc = 0; dc < cell.colSpan; dc++) {
@@ -300,25 +300,13 @@ function parseTable(
 }
 
 /** 셀 내부 텍스트 추출 — PARALIST > P 재귀, 중첩 테이블은 평탄화 */
-function extractCellText(
-  cellEl: Element,
-  paraShapeMap: Map<string, ParaShapeInfo>,
-  sectionNum: number,
-  warnings: ParseWarning[],
-): string {
+function extractCellText(cellEl: Element): string {
   const textParts: string[] = []
-  collectCellText(cellEl, textParts, paraShapeMap, sectionNum, warnings, 0)
+  collectCellText(cellEl, textParts, 0)
   return textParts.filter(Boolean).join("\n").trim()
 }
 
-function collectCellText(
-  node: Element,
-  parts: string[],
-  paraShapeMap: Map<string, ParaShapeInfo>,
-  sectionNum: number,
-  warnings: ParseWarning[],
-  depth: number,
-): void {
+function collectCellText(node: Element, parts: string[], depth: number): void {
   if (depth > 20) return
   const children = node.childNodes
   for (let i = 0; i < children.length; i++) {
@@ -333,7 +321,7 @@ function collectCellText(
       // 중첩 테이블 — 텍스트로 평탄화
       parts.push("[중첩 테이블]")
     } else {
-      collectCellText(el, parts, paraShapeMap, sectionNum, warnings, depth + 1)
+      collectCellText(el, parts, depth + 1)
     }
   }
 }

--- a/src/hwpml/parser.ts
+++ b/src/hwpml/parser.ts
@@ -1,0 +1,378 @@
+/** HWPML 2.x 파서 — XML 기반 한컴 문서 (.hwp with XML content) */
+
+import { DOMParser } from "@xmldom/xmldom"
+import type { IRBlock, InternalParseResult, ParseOptions, ParseWarning, DocumentMetadata, OutlineItem } from "../types.js"
+import { blocksToMarkdown, buildTable } from "../table/builder.js"
+import { parsePageRange } from "../page-range.js"
+import { stripDtd } from "../utils.js"
+import type { CellContext } from "../types.js"
+
+const MAX_XML_DEPTH = 200
+const MAX_TABLE_ROWS = 5000
+const MAX_TABLE_COLS = 500
+
+/** ParaShape 헤딩 정보 */
+interface ParaShapeInfo {
+  headingLevel: number | null  // null = 일반 단락, 1-6 = 헤딩 레벨
+}
+
+/** HWPML 문서 파싱 진입점 */
+export function parseHwpmlDocument(buffer: ArrayBuffer, options?: ParseOptions): InternalParseResult {
+  const text = new TextDecoder("utf-8").decode(buffer).replace(/^\uFEFF/, "")
+
+  // &nbsp; 엔티티 치환 (DOCTYPE 제거 전에 처리)
+  const normalized = text.replace(/&nbsp;/g, "&#160;")
+  const xml = stripDtd(normalized)
+
+  const warnings: ParseWarning[] = []
+  const parser = new DOMParser({
+    onError: (_level: string, msg: string) => {
+      warnings.push({ message: `HWPML XML 파싱 경고: ${msg}`, code: "MALFORMED_XML" })
+    },
+  } as ConstructorParameters<typeof DOMParser>[0])
+
+  const doc = parser.parseFromString(xml, "text/xml")
+  if (!doc.documentElement) {
+    return { markdown: "", blocks: [], warnings }
+  }
+
+  const root = doc.documentElement
+
+  // ─── 메타데이터 추출 ──────────────────────────────────
+  const metadata: DocumentMetadata = {}
+  const docSummary = findChild(root, "DOCSUMMARY")
+  if (docSummary) {
+    const title = findChild(docSummary, "TITLE")
+    const author = findChild(docSummary, "AUTHOR")
+    const date = findChild(docSummary, "DATE")
+    if (title) metadata.title = textContent(title).trim()
+    if (author) metadata.author = textContent(author).trim()
+    if (date) metadata.createdAt = textContent(date).trim() || undefined
+  }
+
+  // ─── HEAD: ParaShape 맵 구축 ──────────────────────────
+  const paraShapeMap = buildParaShapeMap(root)
+
+  // ─── BODY 파싱 ────────────────────────────────────────
+  const body = findChild(root, "BODY")
+  if (!body) {
+    return { markdown: "", blocks: [], metadata, warnings }
+  }
+
+  const blocks: IRBlock[] = []
+  const pageFilter = options?.pages ? parsePageRange(options.pages, countSections(body)) : null
+  let sectionIdx = 0
+
+  const children = body.childNodes
+  for (let i = 0; i < children.length; i++) {
+    const el = children[i] as Element
+    if (el.nodeType !== 1) continue
+    if (localName(el) !== "SECTION") continue
+
+    sectionIdx++
+    if (pageFilter && !pageFilter.has(sectionIdx)) continue
+
+    parseSection(el, blocks, paraShapeMap, sectionIdx, warnings)
+  }
+
+  // ─── 헤딩 트리(outline) 구성 ──────────────────────────
+  const outline: OutlineItem[] = blocks
+    .filter(b => b.type === "heading" && b.text)
+    .map(b => ({ level: b.level ?? 1, text: b.text!, pageNumber: b.pageNumber }))
+
+  const markdown = blocksToMarkdown(blocks)
+  return {
+    markdown,
+    blocks,
+    metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
+    outline: outline.length > 0 ? outline : undefined,
+    warnings: warnings.length > 0 ? warnings : undefined,
+  }
+}
+
+// ─── ParaShape 맵 ────────────────────────────────────────
+
+function buildParaShapeMap(root: Element): Map<string, ParaShapeInfo> {
+  const map = new Map<string, ParaShapeInfo>()
+  const head = findChild(root, "HEAD")
+  if (!head) return map
+
+  const mappingTable = findChild(head, "MAPPINGTABLE")
+  if (!mappingTable) return map
+
+  const paraShapeList = findChild(mappingTable, "PARASHAPELIST")
+  if (!paraShapeList) return map
+
+  const children = paraShapeList.childNodes
+  for (let i = 0; i < children.length; i++) {
+    const el = children[i] as Element
+    if (el.nodeType !== 1 || localName(el) !== "PARASHAPE") continue
+    const id = el.getAttribute("Id") ?? ""
+    const headingType = el.getAttribute("HeadingType") ?? "None"
+    const level = parseInt(el.getAttribute("Level") ?? "0", 10)
+    let headingLevel: number | null = null
+    if (headingType === "Outline") {
+      headingLevel = Math.min(level + 1, 6)  // Level 0→H1, 1→H2, ..., 5→H6
+    }
+    map.set(id, { headingLevel })
+  }
+
+  return map
+}
+
+// ─── 섹션 파싱 ───────────────────────────────────────────
+
+function parseSection(
+  section: Element,
+  blocks: IRBlock[],
+  paraShapeMap: Map<string, ParaShapeInfo>,
+  sectionNum: number,
+  warnings: ParseWarning[],
+): void {
+  walkContent(section, blocks, paraShapeMap, sectionNum, warnings, false)
+}
+
+/**
+ * 콘텐츠 노드를 재귀적으로 순회하여 IRBlock 생성.
+ * inHeaderFooter=true일 때 단락/표 블록 출력 억제.
+ */
+function walkContent(
+  node: Element,
+  blocks: IRBlock[],
+  paraShapeMap: Map<string, ParaShapeInfo>,
+  sectionNum: number,
+  warnings: ParseWarning[],
+  inHeaderFooter: boolean,
+  depth: number = 0,
+): void {
+  if (depth > MAX_XML_DEPTH) return
+  const children = node.childNodes
+  for (let i = 0; i < children.length; i++) {
+    const el = children[i] as Element
+    if (el.nodeType !== 1) continue
+    const tag = localName(el)
+
+    if (tag === "HEADER" || tag === "FOOTER") {
+      // 머리글/바닥글 — 텍스트 콘텐츠 무시
+      continue
+    }
+
+    if (tag === "P") {
+      if (!inHeaderFooter) {
+        parseParagraph(el, blocks, paraShapeMap, sectionNum)
+      }
+      continue
+    }
+
+    if (tag === "TABLE") {
+      if (!inHeaderFooter) {
+        parseTable(el, blocks, paraShapeMap, sectionNum, warnings)
+      }
+      continue
+    }
+
+    // PARALIST, SUBLIST, SECTION 내부 등 — 재귀
+    if (tag === "PARALIST" || tag === "SECTION" || tag === "COLDEF") {
+      walkContent(el, blocks, paraShapeMap, sectionNum, warnings, inHeaderFooter, depth + 1)
+      continue
+    }
+
+    // TEXT, SECDEF 등 내부에서도 P/TABLE이 중첩될 수 있음 — 재귀
+    walkContent(el, blocks, paraShapeMap, sectionNum, warnings, inHeaderFooter, depth + 1)
+  }
+}
+
+// ─── 단락 파싱 ───────────────────────────────────────────
+
+function parseParagraph(
+  el: Element,
+  blocks: IRBlock[],
+  paraShapeMap: Map<string, ParaShapeInfo>,
+  sectionNum: number,
+): void {
+  const paraShapeId = el.getAttribute("ParaShape") ?? ""
+  const shapeInfo = paraShapeMap.get(paraShapeId)
+
+  const text = extractParagraphText(el)
+  if (!text) return
+
+  if (shapeInfo?.headingLevel != null) {
+    blocks.push({ type: "heading", text, level: shapeInfo.headingLevel, pageNumber: sectionNum })
+  } else {
+    blocks.push({ type: "paragraph", text, pageNumber: sectionNum })
+  }
+}
+
+/** <P> 에서 텍스트 추출 — <TEXT><CHAR> 순회 */
+function extractParagraphText(p: Element): string {
+  const parts: string[] = []
+  collectCharText(p, parts)
+  return parts.join("").trim()
+}
+
+function collectCharText(node: Element, parts: string[]): void {
+  const children = node.childNodes
+  for (let i = 0; i < children.length; i++) {
+    const el = children[i] as Element
+    if (el.nodeType !== 1) continue
+    const tag = localName(el)
+
+    if (tag === "CHAR") {
+      // textContent — 자식 텍스트 노드 직접 수집
+      const t = textContent(el)
+      if (t) parts.push(t)
+    } else if (tag === "TABLE" || tag === "PICTURE" || tag === "SHAPEOBJECT") {
+      // 단락 내 테이블/이미지는 별도 블록으로 처리되므로 스킵
+    } else if (tag === "AUTONUM") {
+      // 자동 번호 (페이지 번호 등) 스킵
+    } else {
+      collectCharText(el, parts)
+    }
+  }
+}
+
+// ─── 테이블 파싱 ─────────────────────────────────────────
+
+function parseTable(
+  el: Element,
+  blocks: IRBlock[],
+  paraShapeMap: Map<string, ParaShapeInfo>,
+  sectionNum: number,
+  warnings: ParseWarning[],
+): void {
+  const cells: CellContext[] = []
+  const rowCount = parseInt(el.getAttribute("RowCount") ?? "0", 10)
+  const colCount = parseInt(el.getAttribute("ColCount") ?? "0", 10)
+  if (rowCount === 0 || colCount === 0) return
+  if (rowCount > MAX_TABLE_ROWS || colCount > MAX_TABLE_COLS) {
+    warnings.push({ message: `테이블 크기 초과 (${rowCount}x${colCount}) — 스킵`, code: "TRUNCATED_TABLE" })
+    return
+  }
+
+  // <ROW> → <CELL> 순회
+  const children = el.childNodes
+  for (let i = 0; i < children.length; i++) {
+    const rowEl = children[i] as Element
+    if (rowEl.nodeType !== 1 || localName(rowEl) !== "ROW") continue
+
+    const rowCells = rowEl.childNodes
+    for (let j = 0; j < rowCells.length; j++) {
+      const cellEl = rowCells[j] as Element
+      if (cellEl.nodeType !== 1 || localName(cellEl) !== "CELL") continue
+
+      const colAddr = parseInt(cellEl.getAttribute("ColAddr") ?? "0", 10)
+      const rowAddr = parseInt(cellEl.getAttribute("RowAddr") ?? "0", 10)
+      const colSpan = parseInt(cellEl.getAttribute("ColSpan") ?? "1", 10)
+      const rowSpan = parseInt(cellEl.getAttribute("RowSpan") ?? "1", 10)
+
+      // 셀 텍스트: PARALIST > P 재귀 추출
+      const cellText = extractCellText(cellEl, paraShapeMap, sectionNum, warnings)
+
+      cells.push({ text: cellText, colSpan, rowSpan, colAddr, rowAddr })
+    }
+  }
+
+  if (cells.length === 0) return
+
+  // 그리드 배치 (HWP5와 동일한 방식 — colAddr/rowAddr 사용)
+  const grid: (CellContext | null)[][] = Array.from({ length: rowCount }, () => Array(colCount).fill(null))
+  for (const cell of cells) {
+    const r = cell.rowAddr ?? 0
+    const c = cell.colAddr ?? 0
+    if (r >= rowCount || c >= colCount) continue
+    grid[r][c] = cell
+    for (let dr = 0; dr < cell.rowSpan; dr++) {
+      for (let dc = 0; dc < cell.colSpan; dc++) {
+        if (dr === 0 && dc === 0) continue
+        if (r + dr < rowCount && c + dc < colCount) {
+          grid[r + dr][c + dc] = { text: "", colSpan: 1, rowSpan: 1 }
+        }
+      }
+    }
+  }
+
+  const cellRows: CellContext[][] = grid.map(row =>
+    row.map(cell => cell ?? { text: "", colSpan: 1, rowSpan: 1 })
+  )
+
+  const table = buildTable(cellRows)
+  blocks.push({ type: "table", table, pageNumber: sectionNum })
+}
+
+/** 셀 내부 텍스트 추출 — PARALIST > P 재귀, 중첩 테이블은 평탄화 */
+function extractCellText(
+  cellEl: Element,
+  paraShapeMap: Map<string, ParaShapeInfo>,
+  sectionNum: number,
+  warnings: ParseWarning[],
+): string {
+  const textParts: string[] = []
+  collectCellText(cellEl, textParts, paraShapeMap, sectionNum, warnings, 0)
+  return textParts.filter(Boolean).join("\n").trim()
+}
+
+function collectCellText(
+  node: Element,
+  parts: string[],
+  paraShapeMap: Map<string, ParaShapeInfo>,
+  sectionNum: number,
+  warnings: ParseWarning[],
+  depth: number,
+): void {
+  if (depth > 20) return
+  const children = node.childNodes
+  for (let i = 0; i < children.length; i++) {
+    const el = children[i] as Element
+    if (el.nodeType !== 1) continue
+    const tag = localName(el)
+
+    if (tag === "P") {
+      const t = extractParagraphText(el)
+      if (t) parts.push(t)
+    } else if (tag === "TABLE") {
+      // 중첩 테이블 — 텍스트로 평탄화
+      parts.push("[중첩 테이블]")
+    } else {
+      collectCellText(el, parts, paraShapeMap, sectionNum, warnings, depth + 1)
+    }
+  }
+}
+
+// ─── XML 유틸 ────────────────────────────────────────────
+
+function localName(el: Element): string {
+  return (el.tagName || el.localName || "").replace(/^[^:]+:/, "")
+}
+
+function findChild(parent: Element, tag: string): Element | null {
+  const children = parent.childNodes
+  for (let i = 0; i < children.length; i++) {
+    const el = children[i] as Element
+    if (el.nodeType === 1 && localName(el) === tag) return el
+  }
+  return null
+}
+
+function textContent(el: Element): string {
+  const children = el.childNodes
+  const parts: string[] = []
+  for (let i = 0; i < children.length; i++) {
+    const node = children[i]
+    if (node.nodeType === 3) {  // TEXT_NODE
+      parts.push(node.nodeValue || "")
+    } else if (node.nodeType === 1) {
+      parts.push(textContent(node as Element))
+    }
+  }
+  return parts.join("")
+}
+
+function countSections(body: Element): number {
+  let count = 0
+  const children = body.childNodes
+  for (let i = 0; i < children.length; i++) {
+    const el = children[i] as Element
+    if (el.nodeType === 1 && localName(el) === "SECTION") count++
+  }
+  return count
+}

--- a/src/hwpml/parser.ts
+++ b/src/hwpml/parser.ts
@@ -10,6 +10,7 @@ import type { CellContext } from "../types.js"
 const MAX_XML_DEPTH = 200
 const MAX_TABLE_ROWS = 5000
 const MAX_TABLE_COLS = 500
+const MAX_HWPML_BYTES = 50 * 1024 * 1024  // 50MB 상한
 
 /** ParaShape 헤딩 정보 */
 interface ParaShapeInfo {
@@ -18,6 +19,9 @@ interface ParaShapeInfo {
 
 /** HWPML 문서 파싱 진입점 */
 export function parseHwpmlDocument(buffer: ArrayBuffer, options?: ParseOptions): InternalParseResult {
+  if (buffer.byteLength > MAX_HWPML_BYTES) {
+    throw new Error(`HWPML 파일 크기 초과 (${(buffer.byteLength / 1024 / 1024).toFixed(1)}MB > 50MB)`)
+  }
   const text = new TextDecoder("utf-8").decode(buffer).replace(/^\uFEFF/, "")
 
   // &nbsp; 엔티티 치환 (DOCTYPE 제거 전에 처리)
@@ -112,7 +116,8 @@ function buildParaShapeMap(root: Element): Map<string, ParaShapeInfo> {
     const level = parseInt(el.getAttribute("Level") ?? "0", 10)
     let headingLevel: number | null = null
     if (headingType === "Outline") {
-      headingLevel = Math.min(level + 1, 6)  // Level 0→H1, 1→H2, ..., 5→H6
+      const safeLevel = isNaN(level) ? 0 : Math.max(0, level)
+      headingLevel = Math.min(safeLevel + 1, 6)  // Level 0→H1, 1→H2, ..., 5→H6
     }
     map.set(id, { headingLevel })
   }
@@ -210,7 +215,8 @@ function extractParagraphText(p: Element): string {
   return parts.join("").trim()
 }
 
-function collectCharText(node: Element, parts: string[]): void {
+function collectCharText(node: Element, parts: string[], depth: number = 0): void {
+  if (depth > MAX_XML_DEPTH) return
   const children = node.childNodes
   for (let i = 0; i < children.length; i++) {
     const el = children[i] as Element
@@ -226,7 +232,7 @@ function collectCharText(node: Element, parts: string[]): void {
     } else if (tag === "AUTONUM") {
       // 자동 번호 (페이지 번호 등) 스킵
     } else {
-      collectCharText(el, parts)
+      collectCharText(el, parts, depth + 1)
     }
   }
 }
@@ -262,8 +268,9 @@ function parseTable(
 
       const colAddr = parseInt(cellEl.getAttribute("ColAddr") ?? "0", 10)
       const rowAddr = parseInt(cellEl.getAttribute("RowAddr") ?? "0", 10)
-      const colSpan = parseInt(cellEl.getAttribute("ColSpan") ?? "1", 10)
-      const rowSpan = parseInt(cellEl.getAttribute("RowSpan") ?? "1", 10)
+      // colSpan/rowSpan 클램핑: NaN, 음수, 과대값 방어
+      const colSpan = Math.min(Math.max(1, parseInt(cellEl.getAttribute("ColSpan") ?? "1", 10) || 1), MAX_TABLE_COLS)
+      const rowSpan = Math.min(Math.max(1, parseInt(cellEl.getAttribute("RowSpan") ?? "1", 10) || 1), MAX_TABLE_ROWS)
 
       // 셀 텍스트: PARALIST > P 재귀 추출
       const cellText = extractCellText(cellEl)

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { parseHwp5Document } from "./hwp5/parser.js"
 // import { parsePdfDocument } from "./pdf/parser.js"
 import { parseXlsxDocument } from "./xlsx/parser.js"
 import { parseDocxDocument } from "./docx/parser.js"
+import { parseHwpmlDocument } from "./hwpml/parser.js"
 import type { ParseResult, ParseOptions } from "./types.js"
 import { classifyError, toArrayBuffer } from "./utils.js"
 import { fillFormFields } from "./form/filler.js"
@@ -68,6 +69,8 @@ export async function parse(input: string | ArrayBuffer | Buffer, options?: Pars
     }
     case "hwp":
       return parseHwp(buffer, options)
+    case "hwpml":
+      return parseHwpml(buffer, options)
     case "pdf":
       return parsePdf(buffer, options)
     default:
@@ -136,6 +139,16 @@ export async function parseDocx(buffer: ArrayBuffer, options?: ParseOptions): Pr
     return { success: true, fileType: "docx", markdown, blocks, metadata, outline, warnings, images: images?.length ? images : undefined }
   } catch (err) {
     return { success: false, fileType: "docx", error: err instanceof Error ? err.message : "DOCX 파싱 실패", code: classifyError(err) }
+  }
+}
+
+/** HWPML (XML 기반 한컴 문서) 파일을 Markdown으로 변환 */
+export async function parseHwpml(buffer: ArrayBuffer, options?: ParseOptions): Promise<ParseResult> {
+  try {
+    const { markdown, blocks, metadata, outline, warnings } = parseHwpmlDocument(buffer, options)
+    return { success: true, fileType: "hwpml", markdown, blocks, metadata, outline, warnings }
+  } catch (err) {
+    return { success: false, fileType: "hwpml", error: err instanceof Error ? err.message : "HWPML 파싱 실패", code: classifyError(err) }
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -173,7 +173,7 @@ export type ErrorCode =
 
 // ─── 파싱 결과 (discriminated union) ────────────────
 
-export type FileType = "hwpx" | "hwp" | "pdf" | "xlsx" | "docx" | "unknown"
+export type FileType = "hwpx" | "hwp" | "hwpml" | "pdf" | "xlsx" | "docx" | "unknown"
 
 interface ParseResultBase {
   fileType: FileType


### PR DESCRIPTION
## Summary

- HWPML 2.x 포맷(`.hwp` XML 방식) 파싱 지원 추가
- `npx kordoc <file.hwp>` 에서 `지원하지 않는 파일 형식` 오류가 나던 XML 기반 한컴 문서를 Markdown으로 변환
- HWP 5.x 바이너리와 감지 방법이 다름 — 매직바이트가 아닌 XML 시그니처(`<?xml` + `<HWPML`)로 구분

## Changes

**`src/hwpml/parser.ts`** (신규)
- `HEAD > MAPPINGTABLE > PARASHAPELIST`에서 `HeadingType="Outline"` Para Shape를 읽어 헤딩 감지
- `BODY > SECTION > P` 순회, `<CHAR>` 텍스트 추출
- 테이블: `TABLE RowCount/ColCount → ROW → CELL ColAddr/RowAddr/ColSpan/RowSpan` 그리드 배치 (HWP5와 동일)
- `&nbsp;` 엔티티 사전 치환 (xmldom의 외부 엔티티 오류 방지)
- **DoS 방어**: `MAX_TABLE_ROWS=5000`, `MAX_TABLE_COLS=500`, `MAX_XML_DEPTH=200`, 입력 크기 50MB 상한
- `colSpan`/`rowSpan` 클램핑 (NaN·음수·과대값), `Level` 속성 NaN 처리

**`src/detect.ts`**
- `isHwpmlFile()`: 첫 512바이트에서 `<?xml` + `<HWPML` 확인
- `detectFormat()`에 hwpml 분기 추가

**`src/types.ts`**
- `FileType`에 `"hwpml"` 추가

**`src/index.ts`**
- `parseHwpml()` 함수 추가, `parse()` switch에 `"hwpml"` case 추가

## Test plan

- [x] `npx kordoc <hwpml-file.hwp>` → Markdown 출력 확인 (국가연구개발혁신법, 개인정보보호법 테스트)
- [x] 비HWPML `.hwp` (HWP 5.x 바이너리) 영향 없음 확인
- [x] 빌드 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)