### PR TITLE
fix(fillHwpx): self-closing <hp:run/> 빈 셀에 값이 삽입되지 않던 버그 수정

### DIFF
--- a/src/form/filler-hwpx.ts
+++ b/src/form/filler-hwpx.ts
@@ -342,7 +342,23 @@ function setRunText(runEl: Element, text: string): void {
     for (let i = 1; i < tElements.length; i++) {
       clearChildren(tElements[i])
     }
+    return
   }
+
+  // <hp:t>가 없는 빈 run — 한컴오피스가 HWP→HWPX 변환 시 빈 셀의 run을
+  // self-closing(<hp:run charPrIDRef="..."/>)으로 만들면서 <hp:t>를 생략한다.
+  // 이 경우 부모 run의 prefix/namespace를 따라 새로 생성해 추가한다.
+  // 빈 문자열이면 굳이 노드를 만들지 않는다(다른 호출부에서 run을 비울 때 사용).
+  if (!text) return
+
+  const doc = runEl.ownerDocument!
+  const ns = runEl.namespaceURI
+  const qualifiedName = runEl.prefix ? `${runEl.prefix}:t` : "t"
+  const tEl = ns
+    ? doc.createElementNS(ns, qualifiedName)
+    : doc.createElement(qualifiedName)
+  tEl.appendChild(doc.createTextNode(text))
+  runEl.appendChild(tEl)
 }
 
 /** 요소의 모든 자식 노드 제거 */

--- a/tests/filler-hwpx.test.ts
+++ b/tests/filler-hwpx.test.ts
@@ -1,0 +1,71 @@
+/** HWPX 양식 채우기 — 빈 run 처리 회귀 테스트 */
+
+import { describe, it } from "node:test"
+import assert from "node:assert/strict"
+import JSZip from "jszip"
+import { fillHwpx } from "../src/form/filler-hwpx.js"
+
+/**
+ * 한컴오피스가 HWP→HWPX 변환 시 빈 셀을 self-closing <hp:run/>으로
+ * 만들면서 <hp:t>를 생략하는 케이스를 재현한다.
+ */
+async function makeMinimalHwpxWithEmptyValueCell(): Promise<ArrayBuffer> {
+  const zip = new JSZip()
+  zip.file("mimetype", "application/hwp+zip")
+
+  const sectionXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<hs:sec xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section" xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0" pageBreak="0" columnBreak="0" merged="0">
+    <hp:run charPrIDRef="0">
+      <hp:tbl>
+        <hp:tr>
+          <hp:tc name="" header="0" hasMargin="0" protect="0" editable="0" dirty="0" borderFillIDRef="0">
+            <hp:subList id="" textDirection="HORIZONTAL" lineWrap="BREAK" vertAlign="CENTER" linkListIDRef="0" linkListNextIDRef="0" textWidth="0" textHeight="0" hasTextRef="0" hasNumRef="0">
+              <hp:p id="0" paraPrIDRef="0" styleIDRef="0" pageBreak="0" columnBreak="0" merged="0">
+                <hp:run charPrIDRef="0"><hp:t>성명</hp:t></hp:run>
+              </hp:p>
+            </hp:subList>
+            <hp:cellAddr colAddr="0" rowAddr="0"/>
+            <hp:cellSpan colSpan="1" rowSpan="1"/>
+            <hp:cellSz width="2000" height="500"/>
+            <hp:cellMargin left="0" right="0" top="0" bottom="0"/>
+          </hp:tc>
+          <hp:tc name="" header="0" hasMargin="0" protect="0" editable="0" dirty="0" borderFillIDRef="0">
+            <hp:subList id="" textDirection="HORIZONTAL" lineWrap="BREAK" vertAlign="CENTER" linkListIDRef="0" linkListNextIDRef="0" textWidth="0" textHeight="0" hasTextRef="0" hasNumRef="0">
+              <hp:p id="0" paraPrIDRef="0" styleIDRef="0" pageBreak="0" columnBreak="0" merged="0">
+                <hp:run charPrIDRef="0"/>
+              </hp:p>
+            </hp:subList>
+            <hp:cellAddr colAddr="1" rowAddr="0"/>
+            <hp:cellSpan colSpan="1" rowSpan="1"/>
+            <hp:cellSz width="2000" height="500"/>
+            <hp:cellMargin left="0" right="0" top="0" bottom="0"/>
+          </hp:tc>
+        </hp:tr>
+      </hp:tbl>
+    </hp:run>
+  </hp:p>
+</hs:sec>`
+
+  zip.file("Contents/section0.xml", sectionXml)
+  return await zip.generateAsync({ type: "arraybuffer" })
+}
+
+describe("fillHwpx — empty run handling", () => {
+  it("값 셀의 <hp:run>이 <hp:t> 없이 self-closing이어도 값이 삽입된다", async () => {
+    const buffer = await makeMinimalHwpxWithEmptyValueCell()
+    const result = await fillHwpx(buffer, { 성명: "홍길동" })
+
+    assert.equal(result.filled.length, 1, `filled count: ${result.filled.length}`)
+    assert.equal(result.filled[0].label, "성명")
+    assert.equal(result.filled[0].value, "홍길동")
+
+    const zip = await JSZip.loadAsync(result.buffer)
+    const section = await zip.file("Contents/section0.xml")!.async("text")
+
+    assert.ok(
+      section.includes("홍길동"),
+      "출력 XML에 삽입한 값이 실제로 들어있어야 한다 (regression: 이전엔 filled로 보고만 되고 XML엔 안 들어갔음)",
+    )
+  })
+})


### PR DESCRIPTION
## 요약

`fillHwpx`(`hwpx-preserve` 모드)에서 값 셀의 `<hp:run>`이 `<hp:t>` 자식 없이 self-closing 형태일 때 값이 실제로 삽입되지 않는 버그를 수정합니다. 한컴오피스에서 HWP→HWPX로 변환한 양식에서 자주 발생합니다.

이슈: #29

## 문제

`setRunText`는 `<hp:run>` 안의 `<hp:t>`를 찾아 텍스트를 교체하는데, `<hp:t>`가 없으면 if 블록을 스킵하고 아무 동작도 하지 않은 채 종료합니다. 그러나 호출자(`replaceCellText` → `fillHwpx` 두 번째 패스)는 결과를 확인하지 않고 `filled` 배열에 push하여 사용자에게는 성공으로 보고됩니다.

한컴오피스가 HWP→HWPX 변환 시 빈 셀의 paragraph 안에 `<hp:run charPrIDRef=\"...\"/>` (self-closing)만 만들고 `<hp:t>`는 생성하지 않기 때문에, 이런 양식에서는 대부분의 필드가 false-positive로 보고됩니다.

## 수정

`setRunText`에서 `<hp:t>`가 없으면 부모 run의 prefix/namespace를 따라 새로 생성해 추가합니다.

\`\`\`typescript
if (tElements.length > 0) {
  // 기존 동작 (변경 없음)
  ...
  return
}
// <hp:t>가 없는 경우 — 새로 생성
if (!text) return  // 빈 문자열로 호출되는 케이스(run 비우기)와 동작 유지
const doc = runEl.ownerDocument!
const ns = runEl.namespaceURI
const qualifiedName = runEl.prefix ? \`\${runEl.prefix}:t\` : \"t\"
const tEl = ns
  ? doc.createElementNS(ns, qualifiedName)
  : doc.createElement(qualifiedName)
tEl.appendChild(doc.createTextNode(text))
runEl.appendChild(tEl)
\`\`\`

## 회귀 테스트

`tests/filler-hwpx.test.ts` 추가. self-closing `<hp:run/>`을 가진 minimal HWPX를 만들고 `fillHwpx` 호출 후 출력 XML에 실제로 값이 삽입되는지 검증합니다.

## 검증

- 신규 테스트 1건 추가 통과
- 기존 319개 테스트 모두 회귀 없음 (`npm test`)
- 실제 한컴오피스 변환 신청서 양식으로 수동 검증: 모든 핵심 필드 XML에 정상 삽입 확인