### PR TITLE
fix(roundtrip): 문단 통째 교체 시 원본 들여쓰기 소실 수정

### DIFF
--- a/src/roundtrip/source-map.ts
+++ b/src/roundtrip/source-map.ts
@@ -535,8 +535,22 @@ function finalizeTable(table: ScanTable): void {
  * 문단 텍스트 치환용 splice 생성 — filler-hwpx.ts replaceCellText와 동일 전략:
  * 첫 hp:t에 새 텍스트(이스케이프), 나머지 hp:t는 비움. run 구조/charPr 보존.
  * t가 없으면 첫 run 끝에 <hp:t> 삽입. 실패 시 null.
+ *
+ * IR 텍스트는 sanitize로 양끝 공백이 제거된 상태라, 통째 교체 시 원본의
+ * 선행 공백(들여쓰기)/후행 공백이 소실된다 — 원본 t-도메인 텍스트에서
+ * 양끝 공백을 복원해 새 텍스트에 입힌다 (재파싱 IR은 동일하게 유지됨).
  */
 export function buildParagraphSplices(para: ScanParagraph, newText: string, xml?: string): SpliceEdit[] | null {
+  if (newText && xml) {
+    const orig = paraTText(para, xml)
+    if (orig && orig.trim() !== "") {
+      const lead = orig.match(/^\s*/)![0]
+      const trail = orig.match(/\s*$/)![0]
+      if ((lead || trail) && newText.trim() !== "") {
+        newText = lead + newText.replace(/^\s+|\s+$/g, "") + trail
+      }
+    }
+  }
   const escaped = escapeXmlText(newText)
   if (para.tRanges.length > 0) {
     const splices: SpliceEdit[] = []

--- a/tests/session-api.test.ts
+++ b/tests/session-api.test.ts
@@ -135,6 +135,32 @@ describe("HwpxSession.patchBlocks", () => {
     assert.equal(res.verification, undefined)
   })
 
+  it("문단 편집: 원본 들여쓰기(선행 공백/전각공백) 보존", async () => {
+    const section = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<hs:sec xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section" xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph">
+  <hp:p id="0"><hp:run charPrIDRef="0"><hp:t>  ○ 25일 발행 당일 : 익월 게재</hp:t></hp:run></hp:p>
+  <hp:p id="1"><hp:run charPrIDRef="0"><hp:t>　○ 전각공백 들여쓰기 줄</hp:t></hp:run></hp:p>
+</hs:sec>`
+    const zip = new JSZip()
+    zip.file("mimetype", "application/hwp+zip")
+    zip.file("Contents/section0.xml", section)
+    const original = new Uint8Array(await zip.generateAsync({ type: "arraybuffer" }))
+
+    const session = await HwpxSession.open(original)
+    const i0 = session.blocks.findIndex(b => b.text?.includes("25일"))
+    const i1 = session.blocks.findIndex(b => b.text?.includes("전각공백"))
+    const res = await session.patchBlocks([
+      { blockIndex: i0, newText: "○ 5일경 : 수정된 텍스트" },
+      { blockIndex: i1, newText: "○ 전각공백 수정됨" },
+    ])
+    assert.ok(res.success)
+    assert.equal(res.applied, 2)
+
+    const outXml = await (await JSZip.loadAsync(res.data!)).file("Contents/section0.xml")!.async("text")
+    assert.ok(outXml.includes("<hp:t>  ○ 5일경 : 수정된 텍스트</hp:t>"), "일반 공백 들여쓰기 보존")
+    assert.ok(outXml.includes("<hp:t>　○ 전각공백 수정됨</hp:t>"), "전각공백 들여쓰기 보존")
+  })
+
   it("표 셀 편집: 격자 좌표로 적용", async () => {
     const { original } = await makeSynthetic()
     const session = await HwpxSession.open(original)


### PR DESCRIPTION
## 문제

클릭-편집(HwpxSession.patchBlocks)으로 문단을 수정하면 **해당 줄의 들여쓰기가 사라져 왼쪽으로 튀어나옴** (kordoc-ai Phase C 실사용 중 발견).

원인: IR 텍스트는 sanitize로 양끝 공백이 제거된 상태인데, `buildParagraphSplices`가 문단을 통째 교체하면서 원본 `<hp:t>`의 선행 공백(`"  "` / 전각공백 `"　"`)을 버림.

## 수정

`buildParagraphSplices`에서 원본 t-도메인 텍스트(`paraTText`)의 양끝 공백을 복원해 새 텍스트에 입힘.
- session / patchHwpx / fillHwpx / 표 셀 패치가 모두 이 함수를 공유 — **"n회 patchBlocks ≡ 일괄 patchHwpx" 동등성 유지**
- 재파싱 IR은 불변 (sanitize가 다시 제거하므로 텍스트 동등성 유지)
- 공백-only 문단, 빈 newText(비우기)는 기존 동작 유지

## 검증

- 신규 회귀 테스트: 일반 공백 + 전각공백 들여쓰기 보존 (tests/session-api.test.ts)
- 전체 **517/517 통과** (동등성 CI 게이트 포함)
- kordoc-ai 사이드카 edit/fill E2E 12 통과 (링크 dist 재빌드 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)