### PR TITLE
[codex] fix hwpx parse hang

### DIFF
--- a/src/hwpx/equation.ts
+++ b/src/hwpx/equation.ts
@@ -209,13 +209,37 @@ function findBrackets(eqString: string, startIdx: number, direction: 0 | 1): [nu
  * `{` and return the outer `{...}` span.
  */
 function findOutterBrackets(eqString: string, startIdx: number): [number, number] {
-  let idx = startIdx
-  while (true) {
-    idx -= 1
-    if (idx < 0) throw new Error("cannot find bracket")
-    if (eqString[idx] === "{") break
+  const outer = findEnclosingBrackets(eqString, startIdx)
+  if (!outer) throw new Error("cannot find bracket")
+  return outer
+}
+
+/**
+ * Find the nearest `{...}` group that actually encloses `startIdx`.
+ * A previous closed group such as `_ { x } HULKBAR { y }` must not be
+ * treated as the outer wrapper for `HULKBAR`.
+ */
+function findEnclosingBrackets(eqString: string, startIdx: number): [number, number] | null {
+  let depth = 0
+  for (let idx = startIdx - 1; idx >= 0; idx--) {
+    const ch = eqString[idx]
+    if (ch === "}") {
+      depth += 1
+    } else if (ch === "{") {
+      if (depth > 0) {
+        depth -= 1
+        continue
+      }
+      try {
+        const [start, end] = findBrackets(eqString, idx, 1)
+        if (start === idx && end > startIdx) return [start, end]
+      } catch {
+        return null
+      }
+      return null
+    }
   }
-  return findBrackets(eqString, idx, 1)
+  return null
 }
 
 // ─── Rewrite passes ───────────────────────────────────────────────────────
@@ -282,8 +306,9 @@ function replaceAllMatrix(eqString: string): string {
         const elem = replaceElements(input.slice(eStart, eEnd))
         let beforeMat: string
         let afterMat: string
-        if (matElem.removeOutterBrackets) {
-          const [bStart, bEnd] = findOutterBrackets(input, cursor)
+        const outer = matElem.removeOutterBrackets ? findEnclosingBrackets(input, cursor) : null
+        if (outer && outer[1] >= eEnd) {
+          const [bStart, bEnd] = outer
           beforeMat = input.slice(0, bStart)
           afterMat = input.slice(bEnd)
         } else {
@@ -312,10 +337,11 @@ function replaceAllBar(eqString: string): string {
       if (cursor === -1) break
       try {
         const [eStart, eEnd] = findBrackets(input, cursor, 1)
-        const [bStart, bEnd] = findOutterBrackets(input, cursor)
         const elem = input.slice(eStart, eEnd)
-        const beforeBar = input.slice(0, bStart)
-        const afterBar = input.slice(bEnd)
+        const outer = findEnclosingBrackets(input, cursor)
+        const [replaceStart, replaceEnd] = outer && outer[1] >= eEnd ? outer : [cursor, eEnd]
+        const beforeBar = input.slice(0, replaceStart)
+        const afterBar = input.slice(replaceEnd)
         input = beforeBar + barElem + elem + afterBar
       } catch {
         return input

--- a/src/hwpx/parser.ts
+++ b/src/hwpx/parser.ts
@@ -765,7 +765,7 @@ async function resolveSectionPaths(zip: JSZip): Promise<string[]> {
 
   // fallback: section*.xml 직접 검색
   const sectionFiles = zip.file(/[Ss]ection\d+\.xml$/)
-  return sectionFiles.map(f => f.name).sort()
+  return sectionFiles.map(f => f.name).sort(compareSectionPaths)
 }
 
 function parseSectionPathsFromManifest(xml: string): string[] {
@@ -774,17 +774,12 @@ function parseSectionPathsFromManifest(xml: string): string[] {
   const items = doc.getElementsByTagName("opf:item")
   const spine = doc.getElementsByTagName("opf:itemref")
 
-  const isSectionId = (id: string) => /^s/i.test(id) || id.toLowerCase().includes("section")
   const idToHref = new Map<string, string>()
   for (let i = 0; i < items.length; i++) {
     const item = items[i]
     const id = item.getAttribute("id") || ""
-    let href = item.getAttribute("href") || ""
-    const mediaType = item.getAttribute("media-type") || ""
-    if (!isSectionId(id) && !mediaType.includes("xml")) continue
-    if (!href.startsWith("/") && !href.startsWith("Contents/") && isSectionId(id))
-      href = "Contents/" + href
-    idToHref.set(id, href)
+    const href = normalizeSectionHref(item.getAttribute("href") || "")
+    if (id && href) idToHref.set(id, href)
   }
 
   if (spine.length > 0) {
@@ -795,10 +790,21 @@ function parseSectionPathsFromManifest(xml: string): string[] {
     }
     if (ordered.length > 0) return ordered
   }
-  return Array.from(idToHref.entries())
-    .filter(([id]) => isSectionId(id))
-    .sort((a, b) => a[0].localeCompare(b[0]))
-    .map(([, href]) => href)
+  return Array.from(idToHref.values()).sort(compareSectionPaths)
+}
+
+function normalizeSectionHref(href: string): string | null {
+  if (!href) return null
+  let normalized = href.replace(/^\/+/, "")
+  if (isPathTraversal(normalized)) return null
+  if (/^[Ss]ection\d+\.xml$/.test(normalized)) normalized = "Contents/" + normalized
+  return /(?:^|\/)[Ss]ection\d+\.xml$/.test(normalized) ? normalized : null
+}
+
+function compareSectionPaths(a: string, b: string): number {
+  const ai = Number(a.match(/[Ss]ection(\d+)\.xml$/)?.[1] ?? Number.MAX_SAFE_INTEGER)
+  const bi = Number(b.match(/[Ss]ection(\d+)\.xml$/)?.[1] ?? Number.MAX_SAFE_INTEGER)
+  return ai === bi ? a.localeCompare(b) : ai - bi
 }
 
 // ─── 헤딩 감지 (스타일 기반) ────────────────────────

--- a/src/roundtrip/hwpx-entries.ts
+++ b/src/roundtrip/hwpx-entries.ts
@@ -42,8 +42,10 @@ function sectionPathsFromManifest(xml: string): string[] {
 
 function normalizeSectionHref(href: string): string | null {
   if (!href) return null
-  let normalized = href.replace(/^\/+/, "")
-  if (normalized.includes("..") || normalized.startsWith("/")) return null
+  let normalized = href.replace(/\\/g, "/").replace(/^\/+/, "")
+  if (normalized.includes("\x00")) return null
+  if (/^[A-Za-z]:/.test(normalized)) return null
+  if (normalized.split("/").some(s => s === "..")) return null
   if (/^[Ss]ection\d+\.xml$/.test(normalized)) normalized = "Contents/" + normalized
   return /(?:^|\/)[Ss]ection\d+\.xml$/.test(normalized) ? normalized : null
 }

--- a/src/roundtrip/hwpx-entries.ts
+++ b/src/roundtrip/hwpx-entries.ts
@@ -17,11 +17,10 @@ export async function resolveSectionEntryNames(zip: JSZip): Promise<string[]> {
     const paths = sectionPathsFromManifest(xml).filter(p => zip.file(p) !== null)
     if (paths.length > 0) return paths
   }
-  return Object.keys(zip.files).filter(n => /[Ss]ection\d+\.xml$/.test(n)).sort()
+  return Object.keys(zip.files).filter(n => /[Ss]ection\d+\.xml$/.test(n)).sort(compareSectionPaths)
 }
 
 function sectionPathsFromManifest(xml: string): string[] {
-  const isSectionId = (id: string) => /^s/i.test(id) || id.toLowerCase().includes("section")
   const attr = (tag: string, name: string): string => {
     const m = tag.match(new RegExp(`(?:^|\\s)${name}\\s*=\\s*(?:"([^"]*)"|'([^']*)')`))
     return m ? (m[1] ?? m[2]) : ""
@@ -29,11 +28,8 @@ function sectionPathsFromManifest(xml: string): string[] {
   const idToHref = new Map<string, string>()
   for (const m of xml.matchAll(/<opf:item(\s(?:"[^"]*"|'[^']*'|[^>"'])*?)\/?>/g)) {
     const id = attr(m[1], "id")
-    let href = attr(m[1], "href")
-    const mediaType = attr(m[1], "media-type")
-    if (!isSectionId(id) && !mediaType.includes("xml")) continue
-    if (!href.startsWith("/") && !href.startsWith("Contents/") && isSectionId(id)) href = "Contents/" + href
-    if (id) idToHref.set(id, href)
+    const href = normalizeSectionHref(attr(m[1], "href"))
+    if (id && href) idToHref.set(id, href)
   }
   const ordered: string[] = []
   for (const m of xml.matchAll(/<opf:itemref(\s(?:"[^"]*"|'[^']*'|[^>"'])*?)\/?>/g)) {
@@ -41,8 +37,19 @@ function sectionPathsFromManifest(xml: string): string[] {
     if (href) ordered.push(href)
   }
   if (ordered.length > 0) return ordered
-  return Array.from(idToHref.entries())
-    .filter(([id]) => isSectionId(id))
-    .sort((a, b) => a[0].localeCompare(b[0]))
-    .map(([, href]) => href)
+  return Array.from(idToHref.values()).sort(compareSectionPaths)
+}
+
+function normalizeSectionHref(href: string): string | null {
+  if (!href) return null
+  let normalized = href.replace(/^\/+/, "")
+  if (normalized.includes("..") || normalized.startsWith("/")) return null
+  if (/^[Ss]ection\d+\.xml$/.test(normalized)) normalized = "Contents/" + normalized
+  return /(?:^|\/)[Ss]ection\d+\.xml$/.test(normalized) ? normalized : null
+}
+
+function compareSectionPaths(a: string, b: string): number {
+  const ai = Number(a.match(/[Ss]ection(\d+)\.xml$/)?.[1] ?? Number.MAX_SAFE_INTEGER)
+  const bi = Number(b.match(/[Ss]ection(\d+)\.xml$/)?.[1] ?? Number.MAX_SAFE_INTEGER)
+  return ai === bi ? a.localeCompare(b) : ai - bi
 }

--- a/tests/hwpx-equation.test.ts
+++ b/tests/hwpx-equation.test.ts
@@ -53,6 +53,12 @@ describe("hmlToLatex — vec / bar", () => {
     const out = hmlToLatex("{ hat {x} }").replace(/\s+/g, "")
     assert.equal(out, "\\widehat{x}")
   })
+
+  it("바깥 중괄호 없는 bar 입력도 멈추지 않고 변환한다", () => {
+    const out = hmlToLatex("||bar {v}^{*}(u)-I _{δ} bar {v}^{*}(u)|| _{∞}").replace(/\s+/g, "")
+    assert.ok(out.includes("\\overline{v}"), out)
+    assert.ok(!out.includes("HULKBAR"), out)
+  })
 })
 
 describe("hmlToLatex — matrix / cases", () => {
@@ -68,6 +74,12 @@ describe("hmlToLatex — matrix / cases", () => {
     const out = hmlToLatex("{ cases { 1 & x>0 # 0 & x<=0 } }")
     assert.ok(out.includes("\\begin{cases}"))
     assert.ok(out.includes("\\end{cases}"))
+  })
+
+  it("바깥 중괄호 없는 cases 입력도 토큰을 소비한다", () => {
+    const out = hmlToLatex("cases { nI Δ t, λ=1, # I Δ t{1-λ^{n}} over {1-λ}, 0≤λ<1 }")
+    assert.ok(out.includes("\\begin{cases}"), out)
+    assert.ok(!out.includes("HULKCASE"), out)
   })
 })
 


### PR DESCRIPTION
## 요약
- HWPX manifest에서 실제 본문 섹션인 `sectionN.xml`만 섹션으로 인식하도록 수정했습니다.
- HML 수식 변환에서 바깥 중괄호 없이 쓰인 `bar {v}` / `cases { ... }` 형태가 멈추지 않고 정상 종료되도록 고쳤습니다.
- 라운드트립 HWPX 섹션 해석도 파서와 같은 기준으로 맞추고, 관련 회귀 테스트를 추가했습니다.

## 원인
일부 HWPX 문서의 manifest spine에는 본문 섹션 외에도 header, script, settings 같은 비본문 엔트리가 포함될 수 있습니다. 기존 로직은 `s`로 시작하는 id나 XML media type을 넓게 섹션으로 간주해서, 실제 본문이 아닌 XML까지 섹션 목록에 섞일 수 있었습니다.

또한 HML 수식 변환기에서 `bar {v}`처럼 바깥 중괄호가 없는 accent 수식이 들어오면 이전에 닫힌 중괄호 그룹을 바깥 그룹으로 잘못 잡았습니다. 그 결과 `HULKBAR` 토큰을 소비하지 못하고 문자열을 반복해서 키우는 문제가 있었습니다.

## 변경 내용
- manifest 기반 섹션 해석을 `href`가 `sectionN.xml`인 항목으로 제한했습니다.
- 섹션 fallback 정렬도 숫자 순서 기준으로 명확히 했습니다.
- 수식 변환에서 현재 토큰을 실제로 감싸는 중괄호만 outer group으로 인정하도록 수정했습니다.
- 바깥 중괄호가 없는 matrix/accent 계열 토큰도 안전하게 변환되도록 처리했습니다.

## 검증
- `npm test` (519 pass)
- `npm run build`
