### PR TITLE
feat(hwpx): add initial native equation generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,11 @@ import { markdownToHwpx } from "kordoc"
 const hwpxBuffer = await markdownToHwpx("# 제목\n\n본문 텍스트\n\n| 이름 | 직급 |\n| --- | --- |\n| 홍길동 | 과장 |")
 writeFileSync("출력.hwpx", Buffer.from(hwpxBuffer))
 
+// display math block은 HWPX native 수식(<hp:equation>)으로 생성됩니다.
+// 초기 지원 범위는 \frac, \sqrt, 첨자/위첨자, Greek, 적분/극한,
+// 화살표, 관계 연산자, matrix 계열의 제한된 LaTeX-like subset입니다.
+const withEquation = await markdownToHwpx("피타고라스\n\n$$a^2 + b^2 = c^2$$")
+
 // 공문서 모드 — 항목부호 8단계 + 내어쓰기 + 공식 여백/명조 자동
 const gongmun = await markdownToHwpx("1. 추진배경\n  - 세부 항목\n2. 추진계획", {
   gongmun: { preset: "보고서" },  // official | report | plan | notice | minutes

--- a/bench/fuzz-sweep.mjs
+++ b/bench/fuzz-sweep.mjs
@@ -16,7 +16,7 @@
 
 import { readdir, readFile, writeFile, mkdir } from "node:fs/promises"
 import { join, relative } from "node:path"
-import { parse } from "../dist/index.js"
+import { parse, markdownToHwpx } from "../dist/index.js"
 
 const root = new URL(".", import.meta.url).pathname
 const args = process.argv.slice(2)
@@ -120,11 +120,60 @@ for (const file of files) {
   }
 }
 
+// ─── markdownToHwpx fuzz (생성기 강건성) ─────────────
+// markdownToHwpx는 MCP/CLI로 비신뢰 md를 받는다 — parse()와 같은 crash/hang/slow
+// 게이트 + 산출물이 parse로 되읽히는지(genInvalid)까지 잠근다 (PR #39 게이트 공백 봉합).
+const MD_ATOMS = [
+  "# 제목", "본문 문단입니다", "- 리스트 항목", "1. 순서 항목", "2) 괄호 항목",
+  "| a | b |\n| --- | --- |\n| 1 | 2 |",
+  "<table><tr><td rowspan=\"2\">셀</td><td>b</td></tr><tr><td>c</td></tr></table>",
+  "$$a + b$$", "$$\\frac{x}{y}$$", "$$\\begin{pmatrix} a \\\\ b \\end{pmatrix}$$",
+  "$$", "$$ 미종결 수식 텍스트", "\\$\\$ 이스케이프", "$$x$$ 뒤 텍스트",
+  "$$" + "{".repeat(2000), "$$" + "\\frac".repeat(500) + "$$",
+  "```\ncode block\n```", "> 인용문", "***", "x".repeat(5000),
+  "α β ∑ ∫ 한글 \\* \\| 이스케이프", "**굵게** *기울임* `코드`",
+]
+function makeMdDoc(rng) {
+  const n = 3 + Math.floor(rng() * 12)
+  const parts = []
+  for (let i = 0; i < n; i++) parts.push(MD_ATOMS[Math.floor(rng() * MD_ATOMS.length)])
+  return parts.join(rng() < 0.3 ? "\n" : "\n\n")
+}
+let genInvalid = 0
+const GEN_RUNS = 60
+for (let k = 0; k < GEN_RUNS; k++) {
+  const rng = makeRng(djb2(`mdgen:${k}`))
+  const md = makeMdDoc(rng)
+  const opts = k % 3 === 0 ? { gongmun: { preset: "기안문" } } : undefined
+  const t = performance.now()
+  let outcome, error = null
+  try {
+    const res = await Promise.race([
+      (async () => {
+        const buf = await markdownToHwpx(md, opts)
+        return parse(Buffer.from(buf), { filename: "mdgen.hwpx" })
+      })(),
+      new Promise(resolve => setTimeout(() => resolve("__timeout__"), TIMEOUT_MS).unref()),
+    ])
+    if (res === "__timeout__") { outcome = "hang"; hang++ }
+    else if (res.success) { outcome = "success"; success++ }
+    else { outcome = "gen-invalid"; genInvalid++; error = String(res.error ?? "").slice(0, 120) }
+  } catch (err) {
+    outcome = "crash"; crash++
+    error = String(err?.stack ?? err).slice(0, 300)
+  }
+  const ms = Math.round(performance.now() - t)
+  if (outcome !== "hang" && ms > TIMEOUT_MS) { slow++; outcome = `slow-${outcome}` }
+  rows.push({ file: `mdgen#${k}${opts ? ":gongmun" : ""}`, variant: "mdgen", outcome, code: null, ms, ...(error ? { error } : {}) })
+  if (verbose || outcome !== "success") console.error(`${outcome.padEnd(7)} mdgen ${ms}ms mdgen#${k}${error ? "\n  " + error : ""}`)
+}
+
 const gates = {
   crash: { value: crash, threshold: 0, pass: crash === 0 },
   hang: { value: hang, threshold: 0, pass: hang === 0 },
   noCode: { value: noCode, threshold: 0, pass: noCode === 0 },
   slow: { value: slow, threshold: 0, pass: slow === 0 },
+  genInvalid: { value: genInvalid, threshold: 0, pass: genInvalid === 0 },
 }
 const pass = Object.values(gates).every(g => g.pass)
 const codeDist = {}
@@ -135,12 +184,12 @@ const report = {
   elapsedMs: Math.round(performance.now() - t0),
   runs: rows.length, success, failed, pass, gates, codeDist,
   slowest: [...rows].sort((a, b) => b.ms - a.ms).slice(0, 5).map(r => ({ file: r.file, variant: r.variant, ms: r.ms, outcome: r.outcome })),
-  incidents: rows.filter(r => r.outcome === "crash" || r.outcome === "hang" || r.outcome.startsWith("slow-") || (r.outcome === "error" && !r.code)),
+  incidents: rows.filter(r => r.outcome === "crash" || r.outcome === "hang" || r.outcome === "gen-invalid" || r.outcome.startsWith("slow-") || (r.outcome === "error" && !r.code)),
 }
 await mkdir(join(root, "out"), { recursive: true })
 await writeFile(join(root, "out", "fuzz.json"), JSON.stringify(report, null, 1))
 
-console.log(`\n══ fuzz 스윕 — ${files.length}파일 × ${VARIANTS.length}변형 = ${rows.length}런 (${Math.round(report.elapsedMs / 1000)}s) ══`)
+console.log(`\n══ fuzz 스윕 — ${files.length}파일 × ${VARIANTS.length}변형 + mdgen ${GEN_RUNS}런 = ${rows.length}런 (${Math.round(report.elapsedMs / 1000)}s) ══`)
 for (const [k, g] of Object.entries(gates)) console.log(`  ${g.pass ? "✅" : "❌"} ${k.padEnd(7)} ${g.value} (기준 ${g.threshold})`)
 console.log(`  성공 파싱 ${success} / 정상 실패 ${failed} | 에러코드 분포: ${Object.entries(codeDist).map(([k, v]) => `${k}×${v}`).join(" ")}`)
 console.log(`  최장: ${report.slowest.map(s => `${s.ms}ms ${s.variant} ${s.file.split("/").pop()}`).join(" | ")}`)

--- a/bench/gen-sweep.mjs
+++ b/bench/gen-sweep.mjs
@@ -16,6 +16,7 @@ const FIXTURES = {
   htmlTable: '<table><tr><th rowspan="2">구분</th><th colspan="2">내역</th></tr><tr><td>a</td><td>b</td></tr><tr><td>합계</td><td>1</td><td>2</td></tr></table>\n',
   gongmun: "수신 내부결재\n\n제목 테스트 기안\n\n1. 관련: 행정안전부 공문\n\n2. 다음과 같이 보고합니다.\n\n가. 첫째 항목\n\n나. 둘째 항목\n\n붙임 1부. 끝.\n",
   mixed: "# 사업 개요\n\n○ 기간: 2026년\n\n| 항목 | 값 |\n| --- | --- |\n| a | 1 |\n\n마무리 문단\n",
+  equation: "수식\n\n$$a \\pm b = \\frac{x}{y}$$\n\n끝\n",
 }
 
 const out = {}

--- a/bench/roundtrip.mjs
+++ b/bench/roundtrip.mjs
@@ -37,7 +37,11 @@ const docFilter = (args.find(a => a.startsWith("--doc=")) ?? "").split("=")[1] ?
 // 언이스케이프 (fwd 0.947→0.9996의 주역).
 // 잔여(수용): ④셀 내 <img> → "image" 텍스트化 (바이너리 없음) / hr → 대시 런 비대칭 /
 // fixture basic의 인라인 강조(**굵게**) 마커 소실 — IR이 블록 단위라 재출력 불가.
-const GATES = { fwdCovMicro: 0.999, bwdCovMicro: 0.998, tableExact: 0.72, cellExact: 0.99, genErrors: 0, headingErrors: 0 }
+// equationErrors: fixture $$…$$가 native 수식으로 갔다가 같은 LaTeX(공백 무시)로
+// 돌아오는지 — 코퍼스 md에 $$가 없어 게이트 무감이던 구멍 봉합 (PR #39).
+// lineErrors: lineCheck fixture의 실질 줄(정규화 ≥10자)이 왕복에서 통째로 보존되는지 —
+// 번호 뒤 불필요 줄바꿈·문장 중간 끊김 클래스 고정 (2026-07-03 법령 md 실측 후 편입).
+const GATES = { fwdCovMicro: 0.999, bwdCovMicro: 0.998, tableExact: 0.72, cellExact: 0.99, genErrors: 0, headingErrors: 0, equationErrors: 0, lineErrors: 0 }
 
 const round = (x, d = 6) => (x === null || x === undefined ? null : +x.toFixed(d))
 
@@ -97,6 +101,12 @@ const FIXTURES = [
   { name: "table-merge", md: '<table><tr><th rowspan="2">구분</th><th colspan="2">내역</th></tr><tr><td>세입</td><td>세출</td></tr><tr><td>합계</td><td>1,000</td><td>900</td></tr></table>\n' },
   { name: "mixed", md: "# 사업 개요\n\n○ 기간: 2026년 상반기\n\n| 항목 | 값 |\n| --- | --- |\n| 예산 | 1억 |\n\n마무리 문단입니다.\n" },
   { name: "gongmun", md: "수신 내부결재\n\n제목 테스트 기안\n\n1. 관련: 행정안전부 공문\n\n2. 다음과 같이 보고합니다.\n\n가. 첫째 항목\n\n나. 둘째 항목\n\n붙임 1부.  끝.\n", opts: { gongmun: { preset: "기안문" } } },
+  // 수식 왕복 무결성 게이트 — display math → native <hp:equation> → 인라인 $…$ 재파싱.
+  // 고정점 형태(명시적 중괄호·\leq 등 정규 명령)로 작성 — 별칭 정규화까지 요구하지 않는다.
+  { name: "equation", md: "수식 검증 문단.\n\n$$a \\pm b \\cdot c = \\frac{x}{y}$$\n\n중간 문단.\n\n$$\\sqrt{x^{2} + y^{2}} \\leq z$$\n\n$$\\begin{pmatrix} a & b \\\\ c & d \\end{pmatrix}$$\n\n끝 문단.\n" },
+  // 법령 문서 줄 무결성 게이트(lineCheck) — 조문 번호 뒤 분리·문장 중간 끊김 검출
+  // (2026-07-03 민원처리법 전문 왕복 실측: 228문단 빈문단 0·쪼개짐 0 — 그 구조 클래스를 고정)
+  { name: "law", lineCheck: true, md: "# 민원 처리에 관한 법률\n\n**제2조(정의)** 이 법에서 사용하는 용어의 뜻은 다음과 같다.\n\n1. \"민원\"이란 민원인이 행정기관에 대하여 처분 등 특정한 행위를 요구하는 것을 말하며, 그 종류는 다음 각 목과 같다.\n\n   가. 일반민원\n   1) 법정민원: 법령ㆍ훈령ㆍ예규ㆍ고시ㆍ자치법규 등에서 정한 일정 요건에 따라 인가ㆍ허가ㆍ승인ㆍ특허ㆍ면허 등을 신청하는 민원\n   2) 질의민원: 법령ㆍ제도ㆍ절차 등 행정업무에 관하여 행정기관의 설명이나 해석을 요구하는 민원\n\n2. \"민원인\"이란 행정기관에 민원을 제기하는 개인ㆍ법인 또는 단체를 말한다.\n\n**제4조(민원 처리 담당자의 의무와 보호)** ① 민원을 처리하는 담당자는 담당 민원을 신속ㆍ공정ㆍ친절ㆍ적법하게 처리하여야 한다. <개정 2022. 1. 11.>\n\n② 행정기관의 장은 민원 처리 담당자의 신체적ㆍ정신적 피해의 예방 및 치료 등 대통령령으로 정하는 필요한 조치를 하여야 한다. <신설 2022. 1. 11.>\n\n[제목개정 2022. 1. 11.]\n\n---\n\n> **[개정·예정] 제10조의2 (시행일: 2026. 12. 3.)**\n> ⑥항이 다음과 같이 개정됨: 「도로교통법」 인용이 변경. 그 외 본문은 동일.\n" },
 ]
 
 // ─── 메인 ──────────────────────────────────────────
@@ -134,9 +144,18 @@ for (const file of files) {
 
 // 헤딩 시퀀스 — 레벨은 min(4) 매핑 (paraPr h4가 h4~h6 겸용), 텍스트는 원문 그대로
 const headingSeq = md => [...md.matchAll(/^(#{1,6}) (.+)$/gm)].map(m => `${Math.min(m[1].length, 4)}|${m[2].trim()}`)
+// 수식 시퀀스 — 입력 $$…$$(블록)·재파싱 $…$(인라인) 양쪽을 공백 무시 LaTeX로 정규화
+const mathSeq = md => [...md.matchAll(/\$\$([\s\S]+?)\$\$|\$([^$\n]+)\$/g)].map(m => (m[1] ?? m[2]).replace(/\s+/g, ""))
+// 줄 키 — 마크다운 장식·공백 제거 후 실질 내용만 (짧은 줄은 마커 정규화 노이즈라 제외)
+const lineKeys = md => md.split("\n").map(l => l.trim())
+  .filter(l => l && !/^[-—─*_]{3,}$/.test(l))
+  .map(l => l.replace(/[\\*_`>#|]/g, "").replace(/\s+/g, ""))
+  .filter(k => k.length >= 10)
 
 const fixtureRows = []
 let headingErrors = 0
+let equationErrors = 0
+let lineErrors = 0
 for (const f of FIXTURES) {
   try {
     const rt = await roundtrip(f.md, f.opts)
@@ -151,7 +170,19 @@ for (const f of FIXTURES) {
     const h0 = headingSeq(f.md), h1 = headingSeq(rt.m1)
     const headingOk = h0.length === h1.length && h0.every((x, i) => x === h1[i])
     if (!headingOk) headingErrors++
-    fixtureRows.push({ name: f.name, ok: true, gongmun: !!f.opts, fwdCov: round(fwd.coverage), bwdCov: round(bwd.coverage), refGrams: fwd.total, headings: { ref: h0.length, out: h1.length, ok: headingOk } })
+    // 수식 왕복 무결성 — LaTeX 내용(공백 무시) 시퀀스 완전 일치 (PR #39 게이트)
+    const e0 = mathSeq(f.md), e1 = mathSeq(rt.m1)
+    const equationOk = e0.length === e1.length && e0.every((x, i) => x === e1[i])
+    if (!equationOk) equationErrors++
+    // 줄 무결성(lineCheck fixture) — 원본 실질 줄이 왕복에서 통째로 남아야 한다
+    let lines = null
+    if (f.lineCheck) {
+      const k1 = new Set(lineKeys(rt.m1))
+      const missing = lineKeys(f.md).filter(k => !k1.has(k))
+      lines = { ref: lineKeys(f.md).length, missing: missing.length, ok: missing.length === 0 }
+      if (!lines.ok) lineErrors++
+    }
+    fixtureRows.push({ name: f.name, ok: true, gongmun: !!f.opts, fwdCov: round(fwd.coverage), bwdCov: round(bwd.coverage), refGrams: fwd.total, headings: { ref: h0.length, out: h1.length, ok: headingOk }, equations: { ref: e0.length, out: e1.length, ok: equationOk }, ...(lines ? { lines } : {}) })
   } catch (err) {
     fixtureRows.push({ name: f.name, ok: false, stage: "generate", error: String(err?.message ?? err).slice(0, 300) })
   }
@@ -174,6 +205,8 @@ const gates = {
   cellExact: { value: round(cellExactRate), threshold: GATES.cellExact, pass: cellExactRate >= GATES.cellExact },
   genErrors: { value: genErrors, threshold: GATES.genErrors, pass: genErrors <= GATES.genErrors },
   headingErrors: { value: headingErrors, threshold: GATES.headingErrors, pass: headingErrors <= GATES.headingErrors },
+  equationErrors: { value: equationErrors, threshold: GATES.equationErrors, pass: equationErrors <= GATES.equationErrors },
+  lineErrors: { value: lineErrors, threshold: GATES.lineErrors, pass: lineErrors <= GATES.lineErrors },
 }
 const pass = Object.values(gates).every(g => g.pass)
 
@@ -201,6 +234,6 @@ console.log(`  표: ref=${tblRef} exact=${tblExact} | 셀 ${cellExact}/${cellTot
 console.log("[worst fwd 5]")
 for (const w of report.worstFwd.slice(0, 5)) console.log(`  ${w.fwdCov} bwd=${w.bwdCov} ${w.file}`)
 console.log("[fixtures]")
-for (const f of fixtureRows) console.log(`  ${f.ok ? (f.gongmun ? "공문" : "  ") : "ERR"} fwd=${f.fwdCov ?? "-"} bwd=${f.bwdCov ?? "-"}${f.headings?.ref ? ` 헤딩${f.headings.ok ? "✓" : "✗"} ${f.headings.out}/${f.headings.ref}` : ""} ${f.name}${f.error ? " — " + f.error : ""}`)
+for (const f of fixtureRows) console.log(`  ${f.ok ? (f.gongmun ? "공문" : "  ") : "ERR"} fwd=${f.fwdCov ?? "-"} bwd=${f.bwdCov ?? "-"}${f.headings?.ref ? ` 헤딩${f.headings.ok ? "✓" : "✗"} ${f.headings.out}/${f.headings.ref}` : ""}${f.equations?.ref ? ` 수식${f.equations.ok ? "✓" : "✗"} ${f.equations.out}/${f.equations.ref}` : ""}${f.lines ? ` 줄${f.lines.ok ? "✓" : "✗"} ${f.lines.ref - f.lines.missing}/${f.lines.ref}` : ""} ${f.name}${f.error ? " — " + f.error : ""}`)
 console.log(`report → bench/out/roundtrip.json | ${pass ? "PASS ✅" : "FAIL ❌"}${gateMode ? "" : " (보고 전용 — --gate 시 exit code 반영)"}`)
 if (gateMode && !pass) process.exit(1)

--- a/src/hwpx/equation-generate.ts
+++ b/src/hwpx/equation-generate.ts
@@ -1,0 +1,335 @@
+import { CHAR_NORMAL, PARA_NORMAL, escapeXml } from "./gen-ids.js"
+
+const COMMAND_MAP: Record<string, string> = {
+  alpha: "alpha",
+  beta: "beta",
+  gamma: "gamma",
+  delta: "delta",
+  epsilon: "epsilon",
+  zeta: "zeta",
+  eta: "eta",
+  theta: "theta",
+  iota: "iota",
+  kappa: "kappa",
+  lambda: "lambda",
+  mu: "mu",
+  nu: "nu",
+  xi: "xi",
+  pi: "pi",
+  rho: "rho",
+  sigma: "sigma",
+  tau: "tau",
+  upsilon: "upsilon",
+  phi: "phi",
+  chi: "chi",
+  psi: "psi",
+  omega: "omega",
+  Gamma: "GAMMA",
+  Delta: "DELTA",
+  Theta: "THETA",
+  Lambda: "LAMBDA",
+  Xi: "XI",
+  Pi: "PI",
+  Sigma: "SIGMA",
+  Upsilon: "UPSILON",
+  Phi: "PHI",
+  Psi: "PSI",
+  Omega: "OMEGA",
+  le: "LEQ",
+  leq: "LEQ",
+  ge: "GEQ",
+  geq: "GEQ",
+  ne: "!=",
+  neq: "!=",
+  pm: "+-",
+  mp: "-+",
+  times: "TIMES",
+  cdot: "cdot",
+  ast: "ast",
+  circ: "CIRC",
+  bullet: "BULLET",
+  in: "IN",
+  notin: "NOTIN",
+  subset: "SUBSET",
+  subseteq: "SUBSETEQ",
+  supset: "SUPERSET",
+  supseteq: "SUPSETEQ",
+  cup: "CUP",
+  cap: "SMALLINTER",
+  emptyset: "EMPTYSET",
+  forall: "FORALL",
+  exists: "EXIST",
+  infinity: "INF",
+  infty: "INF",
+  partial: "Partial",
+  nabla: "NABLA",
+  int: "int",
+  iint: "dint",
+  iiint: "tint",
+  oint: "oint",
+  sum: "sum",
+  prod: "prod",
+  lim: "lim",
+  to: "->",
+  rightarrow: "->",
+  leftarrow: "<-",
+  leftrightarrow: "<->",
+  Rightarrow: "RARROW",
+  Leftarrow: "LARROW",
+  Leftrightarrow: "LRARROW",
+  cdots: "CDOTS",
+  ldots: "LDOTS",
+  vdots: "VDOTS",
+  ddots: "DDOTS",
+}
+
+const ACCENT_COMMANDS: Record<string, string> = {
+  bar: "bar",
+  overline: "bar",
+  vec: "vec",
+  hat: "hat",
+  widehat: "hat",
+  tilde: "tilde",
+  widetilde: "tilde",
+  dot: "dot",
+  ddot: "ddot",
+  underline: "under",
+}
+
+const RESERVED_SUBSCRIPT_WORDS = new Set([
+  "rel", "eq", "ne", "le", "ge", "lt", "gt", "equiv", "sim", "approx", "cong", "propto", "parallel", "perp",
+  "and", "or", "not", "in", "notin", "subset", "supset", "sub", "sup", "cup", "cap", "emptyset", "forall", "exists",
+])
+
+interface ReadResult {
+  value: string
+  next: number
+}
+
+interface EquationMetrics {
+  width: number
+  height: number
+  baseline: number
+}
+
+interface EquationXmlOptions {
+  id?: number
+  zOrder?: number
+  width?: number
+  height?: number
+  baseline?: number
+  font?: string
+  autoQuote?: boolean
+}
+
+function skipSpaces(input: string, idx: number): number {
+  while (idx < input.length && /\s/.test(input[idx])) idx++
+  return idx
+}
+
+function normalizeEqEdit(input: string): string {
+  return input
+    .replace(/[ \t\r\n]+/g, " ")
+    .replace(/\s+([,;:)])/g, "$1")
+    .replace(/([([{])\s+/g, "$1")
+    .trim()
+}
+
+function stripMathDelimiters(input: string): string {
+  let s = input.trim()
+  if (s.startsWith("$$") && s.endsWith("$$")) s = s.slice(2, -2).trim()
+  if (s.startsWith("\\[") && s.endsWith("\\]")) s = s.slice(2, -2).trim()
+  return s
+}
+
+function readBalanced(input: string, idx: number, open: string, close: string): ReadResult {
+  let depth = 1
+  let cursor = idx + 1
+  while (cursor < input.length) {
+    const ch = input[cursor]
+    if (ch === "\\") {
+      cursor += 2
+      continue
+    }
+    if (ch === open) depth++
+    else if (ch === close) depth--
+    if (depth === 0) {
+      return { value: input.slice(idx + 1, cursor), next: cursor + 1 }
+    }
+    cursor++
+  }
+  return { value: input.slice(idx + 1), next: input.length }
+}
+
+function readGroupOrToken(input: string, idx: number): ReadResult {
+  const start = skipSpaces(input, idx)
+  if (input[start] === "{") {
+    const group = readBalanced(input, start, "{", "}")
+    return { value: convertLatexFragment(group.value), next: group.next }
+  }
+  if (input[start] === "\\") {
+    const cmd = readCommand(input, start)
+    return { value: cmd.value, next: cmd.next }
+  }
+  return { value: input[start] ?? "", next: Math.min(start + 1, input.length) }
+}
+
+function readCommandName(input: string, idx: number): ReadResult {
+  if (input[idx + 1] === "\\") return { value: "\\", next: idx + 2 }
+  const match = /^[A-Za-z]+/.exec(input.slice(idx + 1))
+  if (match) return { value: match[0], next: idx + 1 + match[0].length }
+  return { value: input[idx + 1] ?? "", next: Math.min(idx + 2, input.length) }
+}
+
+function readCommand(input: string, idx: number): ReadResult {
+  const name = readCommandName(input, idx)
+  const command = name.value
+
+  if (command === "\\") return { value: "#", next: name.next }
+
+  if (command === "frac") {
+    const num = readGroupOrToken(input, name.next)
+    const den = readGroupOrToken(input, num.next)
+    return { value: `{${num.value}} over {${den.value}}`, next: den.next }
+  }
+
+  if (command === "sqrt") {
+    let cursor = skipSpaces(input, name.next)
+    let root: ReadResult | null = null
+    if (input[cursor] === "[") {
+      const opt = readBalanced(input, cursor, "[", "]")
+      root = { value: convertLatexFragment(opt.value), next: opt.next }
+      cursor = opt.next
+    }
+    const body = readGroupOrToken(input, cursor)
+    if (root) return { value: `root {${root.value}} of {${body.value}}`, next: body.next }
+    return { value: `sqrt{${body.value}}`, next: body.next }
+  }
+
+  if (command === "begin") {
+    const env = readGroupOrToken(input, name.next)
+    const endTag = `\\end{${env.value}}`
+    const endIdx = input.indexOf(endTag, env.next)
+    if (endIdx === -1) return { value: env.value, next: env.next }
+    const body = convertLatexFragment(input.slice(env.next, endIdx))
+    const matrix = `{matrix{${body}}}`
+    if (env.value === "pmatrix") return { value: `LEFT ( ${matrix} RIGHT )`, next: endIdx + endTag.length }
+    if (env.value === "bmatrix") return { value: `LEFT [ ${matrix} RIGHT ]`, next: endIdx + endTag.length }
+    if (env.value === "matrix") return { value: matrix, next: endIdx + endTag.length }
+    return { value: body, next: endIdx + endTag.length }
+  }
+
+  if (command === "left" || command === "right") {
+    const cursor = skipSpaces(input, name.next)
+    const delimiter = input[cursor] ?? ""
+    return { value: `${command === "left" ? "LEFT" : "RIGHT"} ${delimiter}`, next: delimiter ? cursor + 1 : cursor }
+  }
+
+  if (command in ACCENT_COMMANDS) {
+    const body = readGroupOrToken(input, name.next)
+    return { value: `${ACCENT_COMMANDS[command]}{${body.value}}`, next: body.next }
+  }
+
+  if (command === "mathrm" || command === "text") {
+    return readGroupOrToken(input, name.next)
+  }
+
+  return { value: COMMAND_MAP[command] ?? command, next: name.next }
+}
+
+function convertLatexFragment(input: string): string {
+  let out = ""
+  let idx = 0
+
+  while (idx < input.length) {
+    const ch = input[idx]
+    if (ch === "\\") {
+      const cmd = readCommand(input, idx)
+      out += ` ${cmd.value} `
+      idx = cmd.next
+      continue
+    }
+    if (ch === "{") {
+      const group = readBalanced(input, idx, "{", "}")
+      out += `{${convertLatexFragment(group.value)}}`
+      idx = group.next
+      continue
+    }
+    if (ch === "_" || ch === "^") {
+      const script = readGroupOrToken(input, idx + 1)
+      out += ` ${ch}{${script.value}}`
+      idx = script.next
+      continue
+    }
+    if (ch === "&") {
+      out += " & "
+      idx++
+      continue
+    }
+    out += ch
+    idx++
+  }
+
+  return normalizeEqEdit(out)
+}
+
+export function quoteReservedKeywords(script: string): string {
+  return script.replace(/([_^])\s*\{([^{}]+)\}/g, (match, op: string, inner: string) => {
+    const value = inner.trim()
+    if (/^".*"$/.test(value)) return match
+    if (!/^[A-Za-z]+$/.test(value)) return match
+    return RESERVED_SUBSCRIPT_WORDS.has(value) ? `${op}{"${value}"}` : match
+  })
+}
+
+export function latexLikeToEqEdit(input: string): string {
+  return quoteReservedKeywords(convertLatexFragment(stripMathDelimiters(input)))
+}
+
+function estimateEquationMetrics(script: string): EquationMetrics {
+  const cleaned = script.replace(/[{}\\^_]/g, "").replace(/\s+/g, " ").trim()
+  const width = Math.min(Math.max(cleaned.length, 5) * 700 + 2000, 40000)
+  const rowCount = Math.max(1, (script.match(/#/g) ?? []).length + 1)
+
+  if (/\bmatrix\b|#/.test(script)) {
+    if (rowCount >= 4) return { width, height: 5500, baseline: 55 }
+    if (rowCount === 3) return { width, height: 4500, baseline: 60 }
+    return { width, height: 3260, baseline: 63 }
+  }
+  if (/\bover\b|\broot\b|\bsqrt\b/.test(script)) return { width, height: 3010, baseline: 69 }
+  return { width, height: 1450, baseline: 71 }
+}
+
+export function generateEquationXml(script: string, options: EquationXmlOptions = {}): string {
+  const zOrder = options.zOrder ?? 0
+  const metrics = estimateEquationMetrics(script)
+  const width = options.width ?? metrics.width
+  const height = options.height ?? metrics.height
+  const baseline = options.baseline ?? metrics.baseline
+  const eqId = options.id ?? 2_000_000_001 + zOrder
+  const font = options.font ?? "HYhwpEQ"
+  const safeScript = options.autoQuote === false ? script : quoteReservedKeywords(script)
+
+  return `<hp:equation id="${eqId}" zOrder="${zOrder}" numberingType="EQUATION" ` +
+    `textWrap="TOP_AND_BOTTOM" textFlow="BOTH_SIDES" lock="0" dropcapstyle="None" ` +
+    `version="Equation Version 60" baseLine="${baseline}" textColor="#000000" ` +
+    `baseUnit="1200" lineMode="CHAR" font="${font}">` +
+    `<hp:sz width="${width}" widthRelTo="ABSOLUTE" height="${height}" heightRelTo="ABSOLUTE" protect="0"/>` +
+    `<hp:pos treatAsChar="1" affectLSpacing="0" flowWithText="1" allowOverlap="0" holdAnchorAndSO="0" ` +
+    `vertRelTo="PARA" horzRelTo="PARA" vertAlign="TOP" horzAlign="LEFT" vertOffset="0" horzOffset="0"/>` +
+    `<hp:outMargin left="56" right="56" top="0" bottom="0"/>` +
+    `<hp:shapeComment>수식입니다.</hp:shapeComment>` +
+    `<hp:script>${escapeXml(safeScript)}</hp:script>` +
+    `</hp:equation>`
+}
+
+export function generateEquationParagraph(input: string, zOrder: number = 0): string {
+  const script = latexLikeToEqEdit(input)
+  const metrics = estimateEquationMetrics(script)
+  const equation = generateEquationXml(script, { zOrder, ...metrics })
+  return `<hp:p id="${2_147_483_648 + zOrder}" paraPrIDRef="${PARA_NORMAL}" styleIDRef="0" pageBreak="0" columnBreak="0" merged="0">` +
+    `<hp:run charPrIDRef="${CHAR_NORMAL}">${equation}<hp:t/></hp:run>` +
+    `<hp:linesegarray><hp:lineseg textpos="0" vertpos="0" vertsize="${metrics.height}" textheight="${metrics.height}" ` +
+    `baseline="${Math.max(metrics.height - 938, 200)}" spacing="600" horzpos="0" horzsize="42520" flags="393216"/>` +
+    `</hp:linesegarray></hp:p>`
+}

--- a/src/hwpx/equation-generate.ts
+++ b/src/hwpx/equation-generate.ts
@@ -1,6 +1,21 @@
-import { CHAR_NORMAL, PARA_NORMAL, escapeXml } from "./gen-ids.js"
+/**
+ * Markdown display math (LaTeX-like subset) → Hancom EqEdit script + <hp:equation> XML.
+ *
+ * 읽기 경로(equation.ts hmlToLatex)의 역방향. 어휘는 equation.ts의 토큰 맵과
+ * 양방향 정합을 유지한다 — 여기서 뿜는 모든 토큰은 hmlToLatex가 같은 LaTeX로
+ * 되읽어야 하며, 전 토큰 왕복 테스트(hwpx-equation-generation.test.ts)가 잠근다.
+ */
 
-const COMMAND_MAP: Record<string, string> = {
+import { CHAR_NORMAL, PARA_NORMAL, escapeXml } from "./gen-ids.js"
+import { CONVERT_MAP, MIDDLE_CONVERT_MAP } from "./equation.js"
+
+// 비신뢰 입력 가드 — markdownToHwpx는 MCP/CLI로 임의 입력을 받는다 (리뷰 #39 ·2).
+const MAX_EQUATION_SOURCE = 10_000
+const MAX_GROUP_DEPTH = 64
+
+// LaTeX 명령 → EqEdit 토큰. 값은 반드시 읽기 맵(CONVERT_MAP)이 같은 LaTeX로
+// 되돌리는 토큰이어야 한다 (왕복 테스트가 전 항목 검증 — 리뷰 #39 ·3).
+export const COMMAND_MAP: Record<string, string> = {
   alpha: "alpha",
   beta: "beta",
   gamma: "gamma",
@@ -45,7 +60,7 @@ const COMMAND_MAP: Record<string, string> = {
   mp: "-+",
   times: "TIMES",
   cdot: "cdot",
-  ast: "ast",
+  ast: "AST",
   circ: "CIRC",
   bullet: "BULLET",
   in: "IN",
@@ -72,7 +87,7 @@ const COMMAND_MAP: Record<string, string> = {
   lim: "lim",
   to: "->",
   rightarrow: "->",
-  leftarrow: "<-",
+  leftarrow: "larrow",
   leftrightarrow: "<->",
   Rightarrow: "RARROW",
   Leftarrow: "LARROW",
@@ -83,10 +98,13 @@ const COMMAND_MAP: Record<string, string> = {
   ddots: "DDOTS",
 }
 
-const ACCENT_COMMANDS: Record<string, string> = {
+// 악센트도 왕복 정합: 값 토큰을 hmlToLatex가 되돌린 명령이 다시 이 맵의 키여야
+// 한다 (bar → \overline → bar 고정점. overrightarrow는 vec의 되읽기 별칭).
+export const ACCENT_COMMANDS: Record<string, string> = {
   bar: "bar",
   overline: "bar",
   vec: "vec",
+  overrightarrow: "vec",
   hat: "hat",
   widehat: "hat",
   tilde: "tilde",
@@ -96,30 +114,17 @@ const ACCENT_COMMANDS: Record<string, string> = {
   underline: "under",
 }
 
-const RESERVED_SUBSCRIPT_WORDS = new Set([
-  "rel", "eq", "ne", "le", "ge", "lt", "gt", "equiv", "sim", "approx", "cong", "propto", "parallel", "perp",
-  "and", "or", "not", "in", "notin", "subset", "supset", "sub", "sup", "cup", "cap", "emptyset", "forall", "exists",
-])
+// EqEdit이 명령으로 해석하는 어휘 = 읽기 맵 키 + 구조 키워드. 첨자/위첨자의
+// 리터럴 단어가 이와 충돌하면 따옴표 보호 (T_{int}의 int가 ∫로 렌더되는 것 방지).
+// 구 하드코딩 18단어는 실제 토큰맵과 무관해 폐기 (리뷰 #39 ·8).
+const RESERVED_WORDS = new Set(
+  [...Object.keys(CONVERT_MAP), ...Object.keys(MIDDLE_CONVERT_MAP), "over", "root", "of"]
+    .filter((w) => /^[A-Za-z]+$/.test(w)),
+)
 
 interface ReadResult {
   value: string
   next: number
-}
-
-interface EquationMetrics {
-  width: number
-  height: number
-  baseline: number
-}
-
-interface EquationXmlOptions {
-  id?: number
-  zOrder?: number
-  width?: number
-  height?: number
-  baseline?: number
-  font?: string
-  autoQuote?: boolean
 }
 
 function skipSpaces(input: string, idx: number): number {
@@ -127,12 +132,10 @@ function skipSpaces(input: string, idx: number): number {
   return idx
 }
 
+// 공백 정리만 한다. 구두점/괄호 접합은 금지 — "RIGHT )"를 "RIGHT)"로 붙이면
+// 공백 토크나이저인 hmlToLatex가 토큰을 못 읽어 왕복이 붕괴한다 (리뷰 #39 ·4).
 function normalizeEqEdit(input: string): string {
-  return input
-    .replace(/[ \t\r\n]+/g, " ")
-    .replace(/\s+([,;:)])/g, "$1")
-    .replace(/([([{])\s+/g, "$1")
-    .trim()
+  return input.replace(/\s+/g, " ").trim()
 }
 
 function stripMathDelimiters(input: string): string {
@@ -161,14 +164,16 @@ function readBalanced(input: string, idx: number, open: string, close: string): 
   return { value: input.slice(idx + 1), next: input.length }
 }
 
-function readGroupOrToken(input: string, idx: number): ReadResult {
+function readGroupOrToken(input: string, idx: number, depth: number): ReadResult {
   const start = skipSpaces(input, idx)
+  // 중첩 상한 초과 — 남은 입력을 리터럴로 폴백 (스택 오버플로 가드, 리뷰 #39 ·2)
+  if (depth > MAX_GROUP_DEPTH) return { value: input.slice(start), next: input.length }
   if (input[start] === "{") {
     const group = readBalanced(input, start, "{", "}")
-    return { value: convertLatexFragment(group.value), next: group.next }
+    return { value: convertLatexFragment(group.value, depth + 1), next: group.next }
   }
   if (input[start] === "\\") {
-    const cmd = readCommand(input, start)
+    const cmd = readCommand(input, start, depth + 1)
     return { value: cmd.value, next: cmd.next }
   }
   return { value: input[start] ?? "", next: Math.min(start + 1, input.length) }
@@ -181,15 +186,15 @@ function readCommandName(input: string, idx: number): ReadResult {
   return { value: input[idx + 1] ?? "", next: Math.min(idx + 2, input.length) }
 }
 
-function readCommand(input: string, idx: number): ReadResult {
+function readCommand(input: string, idx: number, depth: number): ReadResult {
   const name = readCommandName(input, idx)
   const command = name.value
 
   if (command === "\\") return { value: "#", next: name.next }
 
   if (command === "frac") {
-    const num = readGroupOrToken(input, name.next)
-    const den = readGroupOrToken(input, num.next)
+    const num = readGroupOrToken(input, name.next, depth)
+    const den = readGroupOrToken(input, num.next, depth)
     return { value: `{${num.value}} over {${den.value}}`, next: den.next }
   }
 
@@ -198,65 +203,86 @@ function readCommand(input: string, idx: number): ReadResult {
     let root: ReadResult | null = null
     if (input[cursor] === "[") {
       const opt = readBalanced(input, cursor, "[", "]")
-      root = { value: convertLatexFragment(opt.value), next: opt.next }
+      root = { value: convertLatexFragment(opt.value, depth + 1), next: opt.next }
       cursor = opt.next
     }
-    const body = readGroupOrToken(input, cursor)
+    const body = readGroupOrToken(input, cursor, depth)
     if (root) return { value: `root {${root.value}} of {${body.value}}`, next: body.next }
     return { value: `sqrt{${body.value}}`, next: body.next }
   }
 
   if (command === "begin") {
-    const env = readGroupOrToken(input, name.next)
+    const env = readGroupOrToken(input, name.next, depth)
     const endTag = `\\end{${env.value}}`
     const endIdx = input.indexOf(endTag, env.next)
     if (endIdx === -1) return { value: env.value, next: env.next }
-    const body = convertLatexFragment(input.slice(env.next, endIdx))
-    const matrix = `{matrix{${body}}}`
-    if (env.value === "pmatrix") return { value: `LEFT ( ${matrix} RIGHT )`, next: endIdx + endTag.length }
-    if (env.value === "bmatrix") return { value: `LEFT [ ${matrix} RIGHT ]`, next: endIdx + endTag.length }
-    if (env.value === "matrix") return { value: matrix, next: endIdx + endTag.length }
+    const body = convertLatexFragment(input.slice(env.next, endIdx), depth + 1)
+    // matrix 계열은 EqEdit 네이티브 토큰으로 — LEFT (/RIGHT ) 합성보다 왕복이 정확
+    // (hmlToLatex가 pmatrix/bmatrix를 원 환경 그대로 복원한다)
+    if (env.value === "matrix" || env.value === "pmatrix" || env.value === "bmatrix") {
+      return { value: `{${env.value}{${body}}}`, next: endIdx + endTag.length }
+    }
     return { value: body, next: endIdx + endTag.length }
   }
 
   if (command === "left" || command === "right") {
+    const kw = command === "left" ? "LEFT" : "RIGHT"
     const cursor = skipSpaces(input, name.next)
-    const delimiter = input[cursor] ?? ""
-    return { value: `${command === "left" ? "LEFT" : "RIGHT"} ${delimiter}`, next: delimiter ? cursor + 1 : cursor }
+    let delimiter = input[cursor] ?? ""
+    let next = delimiter ? cursor + 1 : cursor
+    if (delimiter === "\\") {
+      // \{ \} \| 등 이스케이프 구분자 — 백슬래시 잔재 없이 원 문자만 (리뷰 #39 ·7).
+      // "LEFT {"는 hmlToLatex replaceBracket이 \left \{ 로 복원하는 실파일 어휘.
+      const escaped = readCommandName(input, cursor)
+      delimiter = escaped.value === "\\" ? "\\" : (COMMAND_MAP[escaped.value] ?? escaped.value)
+      next = escaped.next
+    }
+    return { value: delimiter ? `${kw} ${delimiter}` : kw, next }
   }
 
   if (command in ACCENT_COMMANDS) {
-    const body = readGroupOrToken(input, name.next)
+    const body = readGroupOrToken(input, name.next, depth)
     return { value: `${ACCENT_COMMANDS[command]}{${body.value}}`, next: body.next }
   }
 
   if (command === "mathrm" || command === "text") {
-    return readGroupOrToken(input, name.next)
+    // 리터럴 텍스트 — 변환하지 않고 EqEdit 따옴표로 보호 (int가 ∫로 렌더 방지).
+    // hmlToLatex는 단일 토큰 따옴표를 \text{...}로 되읽어 고정점이 된다.
+    const start = skipSpaces(input, name.next)
+    if (input[start] === "{") {
+      const group = readBalanced(input, start, "{", "}")
+      return { value: `"${group.value}"`, next: group.next }
+    }
+    const tok = readGroupOrToken(input, start, depth)
+    return { value: `"${tok.value}"`, next: tok.next }
   }
 
   return { value: COMMAND_MAP[command] ?? command, next: name.next }
 }
 
-function convertLatexFragment(input: string): string {
+function convertLatexFragment(input: string, depth: number): string {
+  // 중괄호 폭탄 등 기형 입력 — 상한 초과 시 리터럴 폴백 (리뷰 #39 ·2)
+  if (depth > MAX_GROUP_DEPTH) return normalizeEqEdit(input)
+
   let out = ""
   let idx = 0
 
   while (idx < input.length) {
     const ch = input[idx]
     if (ch === "\\") {
-      const cmd = readCommand(input, idx)
+      const cmd = readCommand(input, idx, depth + 1)
       out += ` ${cmd.value} `
       idx = cmd.next
       continue
     }
     if (ch === "{") {
       const group = readBalanced(input, idx, "{", "}")
-      out += `{${convertLatexFragment(group.value)}}`
+      out += `{${convertLatexFragment(group.value, depth + 1)}}`
       idx = group.next
       continue
     }
     if (ch === "_" || ch === "^") {
-      const script = readGroupOrToken(input, idx + 1)
+      const script = readGroupOrToken(input, idx + 1, depth)
       out += ` ${ch}{${script.value}}`
       idx = script.next
       continue
@@ -273,17 +299,25 @@ function convertLatexFragment(input: string): string {
   return normalizeEqEdit(out)
 }
 
-export function quoteReservedKeywords(script: string): string {
-  return script.replace(/([_^])\s*\{([^{}]+)\}/g, (match, op: string, inner: string) => {
-    const value = inner.trim()
-    if (/^".*"$/.test(value)) return match
-    if (!/^[A-Za-z]+$/.test(value)) return match
-    return RESERVED_SUBSCRIPT_WORDS.has(value) ? `${op}{"${value}"}` : match
-  })
+/**
+ * LaTeX 원문 단계에서 첨자/위첨자의 리터럴 예약어를 따옴표 보호.
+ * 변환 전에만 적용 — 변환 산출물(\pi→pi 등)을 재따옴표하지 않기 위함 (리뷰 #39 ·8).
+ */
+export function quoteReservedKeywords(latex: string): string {
+  return latex.replace(/([_^])\s*\{\s*([A-Za-z]+)\s*\}/g, (match, op: string, word: string) =>
+    RESERVED_WORDS.has(word) ? `${op}{"${word}"}` : match)
 }
 
 export function latexLikeToEqEdit(input: string): string {
-  return quoteReservedKeywords(convertLatexFragment(stripMathDelimiters(input)))
+  const src = stripMathDelimiters(input)
+  if (src.length > MAX_EQUATION_SOURCE) return normalizeEqEdit(src)
+  return convertLatexFragment(quoteReservedKeywords(src), 0)
+}
+
+interface EquationMetrics {
+  width: number
+  height: number
+  baseline: number
 }
 
 function estimateEquationMetrics(script: string): EquationMetrics {
@@ -300,36 +334,27 @@ function estimateEquationMetrics(script: string): EquationMetrics {
   return { width, height: 1450, baseline: 71 }
 }
 
-export function generateEquationXml(script: string, options: EquationXmlOptions = {}): string {
-  const zOrder = options.zOrder ?? 0
-  const metrics = estimateEquationMetrics(script)
-  const width = options.width ?? metrics.width
-  const height = options.height ?? metrics.height
-  const baseline = options.baseline ?? metrics.baseline
-  const eqId = options.id ?? 2_000_000_001 + zOrder
-  const font = options.font ?? "HYhwpEQ"
-  const safeScript = options.autoQuote === false ? script : quoteReservedKeywords(script)
+export function generateEquationXml(script: string, zOrder: number = 0): string {
+  const { width, height, baseline } = estimateEquationMetrics(script)
+  const eqId = 2_000_000_001 + zOrder
 
   return `<hp:equation id="${eqId}" zOrder="${zOrder}" numberingType="EQUATION" ` +
     `textWrap="TOP_AND_BOTTOM" textFlow="BOTH_SIDES" lock="0" dropcapstyle="None" ` +
     `version="Equation Version 60" baseLine="${baseline}" textColor="#000000" ` +
-    `baseUnit="1200" lineMode="CHAR" font="${font}">` +
+    `baseUnit="1200" lineMode="CHAR" font="HYhwpEQ">` +
     `<hp:sz width="${width}" widthRelTo="ABSOLUTE" height="${height}" heightRelTo="ABSOLUTE" protect="0"/>` +
     `<hp:pos treatAsChar="1" affectLSpacing="0" flowWithText="1" allowOverlap="0" holdAnchorAndSO="0" ` +
     `vertRelTo="PARA" horzRelTo="PARA" vertAlign="TOP" horzAlign="LEFT" vertOffset="0" horzOffset="0"/>` +
     `<hp:outMargin left="56" right="56" top="0" bottom="0"/>` +
     `<hp:shapeComment>수식입니다.</hp:shapeComment>` +
-    `<hp:script>${escapeXml(safeScript)}</hp:script>` +
+    `<hp:script>${escapeXml(script)}</hp:script>` +
     `</hp:equation>`
 }
 
 export function generateEquationParagraph(input: string, zOrder: number = 0): string {
   const script = latexLikeToEqEdit(input)
-  const metrics = estimateEquationMetrics(script)
-  const equation = generateEquationXml(script, { zOrder, ...metrics })
-  return `<hp:p id="${2_147_483_648 + zOrder}" paraPrIDRef="${PARA_NORMAL}" styleIDRef="0" pageBreak="0" columnBreak="0" merged="0">` +
-    `<hp:run charPrIDRef="${CHAR_NORMAL}">${equation}<hp:t/></hp:run>` +
-    `<hp:linesegarray><hp:lineseg textpos="0" vertpos="0" vertsize="${metrics.height}" textheight="${metrics.height}" ` +
-    `baseline="${Math.max(metrics.height - 938, 200)}" spacing="600" horzpos="0" horzsize="42520" flags="393216"/>` +
-    `</hp:linesegarray></hp:p>`
+  // 다른 생성 문단과 같은 최소 셸 — lineseg/고정 id 없이 한컴 재계산에 맡긴다
+  // (gen-table.ts 표 래핑과 동일 규약)
+  return `<hp:p paraPrIDRef="${PARA_NORMAL}" styleIDRef="0">` +
+    `<hp:run charPrIDRef="${CHAR_NORMAL}">${generateEquationXml(script, zOrder)}</hp:run></hp:p>`
 }

--- a/src/hwpx/equation.ts
+++ b/src/hwpx/equation.ts
@@ -26,7 +26,8 @@ interface MatrixMapping {
 
 // ─── convertMap (from convertMap.json) ────────────────────────────────────
 // Single-token replacements (applied to each whitespace-delimited token).
-const CONVERT_MAP: Record<string, string> = {
+// Exported for equation-generate.ts: 예약어 도출 + 전 토큰 왕복 테스트 (PR #39).
+export const CONVERT_MAP: Record<string, string> = {
   TIMES: "\\times", times: "\\times",
   LEFT: "\\left", RIGHT: "\\right",
   under: "\\underline",
@@ -42,7 +43,8 @@ const CONVERT_MAP: Record<string, string> = {
   "<<": "\\ll", ">>": "\\gg", "<<<": "\\lll", ">>>": "\\ggg",
   PREC: "\\prec", SUCC: "\\succ",
   UPLUS: "\\uplus",
-  "±": "\\pm", "-+": "\\mp", "÷": "\\div",
+  "±": "\\pm", "+-": "\\pm", "-+": "\\mp", "÷": "\\div",
+  cdot: "\\cdot",
   CIRC: "\\circ", BULLET: "\\bullet", DEG: " ^\\circ",
   AST: "\\ast", STAR: "\\bigstar", BIGCIRC: "\\bigcirc",
   EMPTYSET: "\\emptyset",
@@ -118,7 +120,7 @@ const CONVERT_MAP: Record<string, string> = {
 }
 
 // Tokens rewritten to a HULK-prefixed marker, then expanded in second passes.
-const MIDDLE_CONVERT_MAP: Record<string, string> = {
+export const MIDDLE_CONVERT_MAP: Record<string, string> = {
   matrix: "HULKMATRIX",
   pmatrix: "HULKPMATRIX",
   bmatrix: "HULKBMATRIX",
@@ -407,6 +409,13 @@ export function hmlToLatex(hmlEqStr: string): string {
     const t = tokens[i]
     if (t in CONVERT_MAP) tokens[i] = CONVERT_MAP[t]
     else if (t in MIDDLE_CONVERT_MAP) tokens[i] = MIDDLE_CONVERT_MAP[t]
+    else {
+      // EqEdit 리터럴 따옴표("int" 등 — 명령 해석 차단용) → \text{...}로 복원.
+      // 생성기(equation-generate.ts)의 \text→"..." 출력과 고정점을 이룬다.
+      // 공백 포함 다중 토큰 인용은 기존대로 통과 (토큰 단위라 식별 불가).
+      const quoted = /^"(.+)"$/.exec(t)
+      if (quoted) tokens[i] = `\\text{${quoted[1]}}`
+    }
   }
   tokens = tokens.filter(tok => tok.length !== 0)
   tokens = replaceBracket(tokens)

--- a/src/hwpx/gen-gongmun-fit.ts
+++ b/src/hwpx/gen-gongmun-fit.ts
@@ -86,15 +86,17 @@ export function precomputeGongmunList(
   let i = 0
   while (i < blocks.length) {
     if (blocks[i].type !== "list_item") { i++; continue }
-    // 연속 run 수집 — 항목 사이에 낀 표는 run을 끊지 않는다 (공문 관행: 항목 아래
-    // 근거 표를 붙이고 다음 항목 번호가 이어짐). 표 뒤에 항목이 없으면 거기서 종료.
+    // 연속 run 수집 — 항목 사이에 낀 표/수식은 run을 끊지 않는다 (공문 관행: 항목
+    // 아래 근거 표·수식을 붙이고 다음 항목 번호가 이어짐 — 리뷰 #39 ·5).
+    // 표/수식 뒤에 항목이 없으면 거기서 종료.
+    const passThrough = (t: MdBlock["type"]) => t === "table" || t === "html_table" || t === "equation"
     const run: number[] = []
     while (i < blocks.length) {
       const t = blocks[i].type
       if (t === "list_item") { run.push(i); i++; continue }
-      if (t === "table" || t === "html_table") {
+      if (passThrough(t)) {
         let j = i + 1
-        while (j < blocks.length && (blocks[j].type === "table" || blocks[j].type === "html_table")) j++
+        while (j < blocks.length && passThrough(blocks[j].type)) j++
         if (j < blocks.length && blocks[j].type === "list_item") { i = j; continue }
       }
       break

--- a/src/hwpx/gen-section.ts
+++ b/src/hwpx/gen-section.ts
@@ -14,6 +14,7 @@ import {
 import { type MdBlock, generateParagraph, generateRuns } from "./md-runs.js"
 import { type GongmunFitPlan, variantMapper, precomputeGongmunList } from "./gen-gongmun-fit.js"
 import { generateTable, generateHtmlTableXml } from "./gen-table.js"
+import { generateEquationParagraph } from "./equation-generate.js"
 
 // ─── 섹션 속성 (공문서 표준 여백) ────────────────────
 
@@ -100,6 +101,15 @@ export function blocksToSectionXml(
       case "code_block": {
         const codeLines = (block.text || "").split("\n")
         xml = codeLines.map(line => generateParagraph(line || " ", PARA_CODE)).join("\n  ")
+        break
+      }
+      case "equation": {
+        if (isFirst) {
+          const secRun = `<hp:run charPrIDRef="0">${generateSecPr(gongmun)}<hp:t></hp:t></hp:run>`
+          paraXmls.push(`<hp:p paraPrIDRef="0" styleIDRef="0">${secRun}</hp:p>`)
+          isFirst = false
+        }
+        xml = generateEquationParagraph(block.text || "", blockIdx)
         break
       }
       case "blockquote":

--- a/src/hwpx/md-runs.ts
+++ b/src/hwpx/md-runs.ts
@@ -28,7 +28,7 @@ export function buildPrvText(blocks: MdBlock[]): string {
 
 
 export interface MdBlock {
-  type: "paragraph" | "heading" | "table" | "html_table" | "code_block" | "hr" | "blockquote" | "list_item"
+  type: "paragraph" | "heading" | "table" | "html_table" | "code_block" | "equation" | "hr" | "blockquote" | "list_item"
   text?: string
   level?: number
   rows?: string[][]
@@ -49,6 +49,37 @@ export function parseMarkdownToBlocks(md: string): MdBlock[] {
 
     // 빈 줄 스킵
     if (!line.trim()) { i++; continue }
+
+    // Display math block: $$ ... $$
+    const mathStart = line.trimStart().match(/^\$\$(.*)$/)
+    if (mathStart) {
+      const first = mathStart[1]
+      const singleLine = first.match(/^(.*?)\$\$\s*$/)
+      if (singleLine) {
+        const text = singleLine[1].trim()
+        if (text) blocks.push({ type: "equation", text })
+        i++
+        continue
+      }
+
+      const mathLines: string[] = []
+      if (first.trim()) mathLines.push(first)
+      i++
+      while (i < lines.length) {
+        const end = lines[i].indexOf("$$")
+        if (end >= 0) {
+          const before = lines[i].slice(0, end)
+          if (before.trim()) mathLines.push(before)
+          i++
+          break
+        }
+        mathLines.push(lines[i])
+        i++
+      }
+      const text = mathLines.join("\n").trim()
+      if (text) blocks.push({ type: "equation", text })
+      continue
+    }
 
     // 코드블록
     const fenceMatch = line.match(/^(`{3,}|~{3,})(.*)$/)

--- a/src/hwpx/md-runs.ts
+++ b/src/hwpx/md-runs.ts
@@ -39,6 +39,18 @@ export interface MdBlock {
   marker?: string
 }
 
+/** 이스케이프(\$$) 아닌 "$$" 위치 탐색 — 백슬래시 홀수 개 선행이면 이스케이프로 본다 */
+function findMathDelim(s: string, from: number): number {
+  let i = s.indexOf("$$", from)
+  while (i > 0) {
+    let backslashes = 0
+    for (let j = i - 1; j >= 0 && s[j] === "\\"; j--) backslashes++
+    if (backslashes % 2 === 0) break
+    i = s.indexOf("$$", i + 1)
+  }
+  return i
+}
+
 export function parseMarkdownToBlocks(md: string): MdBlock[] {
   const lines = md.split("\n")
   const blocks: MdBlock[] = []
@@ -50,35 +62,49 @@ export function parseMarkdownToBlocks(md: string): MdBlock[] {
     // 빈 줄 스킵
     if (!line.trim()) { i++; continue }
 
-    // Display math block: $$ ... $$
-    const mathStart = line.trimStart().match(/^\$\$(.*)$/)
-    if (mathStart) {
-      const first = mathStart[1]
-      const singleLine = first.match(/^(.*?)\$\$\s*$/)
-      if (singleLine) {
-        const text = singleLine[1].trim()
-        if (text) blocks.push({ type: "equation", text })
+    // Display math block: $$ ... $$ — 같은 줄 닫힘/멀티라인/닫는 $$ 뒤 잔여 텍스트를
+    // 모두 처리하고, 미종결이면 아래 일반 파이프라인으로 폴백한다 (문서 통삼킴 방지,
+    // 리뷰 #39 ·1/·6). 이스케이프된 \$$ 는 여닫이로 세지 않는다 (escapeGfm 접점).
+    const mathOpen = /^\s*\$\$/.exec(line)
+    if (mathOpen) {
+      const afterOpen = line.slice(mathOpen[0].length)
+      const closeSame = findMathDelim(afterOpen, 0)
+      if (closeSame >= 0) {
+        const inner = afterOpen.slice(0, closeSame).trim()
+        const trailing = afterOpen.slice(closeSame + 2).trim()
+        if (inner) blocks.push({ type: "equation", text: inner })
+        if (trailing) blocks.push({ type: "paragraph", text: trailing })
         i++
         continue
       }
-
+      // 멀티라인 수집 — 빈 줄/코드펜스를 만나면 미종결로 판정 (거리 무제한 삼킴 방지)
       const mathLines: string[] = []
-      if (first.trim()) mathLines.push(first)
-      i++
-      while (i < lines.length) {
-        const end = lines[i].indexOf("$$")
+      if (afterOpen.trim()) mathLines.push(afterOpen)
+      let closed = false
+      let trailing = ""
+      let j = i + 1
+      for (; j < lines.length; j++) {
+        const l = lines[j]
+        if (!l.trim() || /^\s*(`{3,}|~{3,})/.test(l)) break
+        const end = findMathDelim(l, 0)
         if (end >= 0) {
-          const before = lines[i].slice(0, end)
+          const before = l.slice(0, end)
           if (before.trim()) mathLines.push(before)
-          i++
+          trailing = l.slice(end + 2).trim()
+          closed = true
+          j++
           break
         }
-        mathLines.push(lines[i])
-        i++
+        mathLines.push(l)
       }
-      const text = mathLines.join("\n").trim()
-      if (text) blocks.push({ type: "equation", text })
-      continue
+      if (closed) {
+        const text = mathLines.join("\n").trim()
+        if (text) blocks.push({ type: "equation", text })
+        if (trailing) blocks.push({ type: "paragraph", text: trailing })
+        i = j
+        continue
+      }
+      // 미종결 — 수식 아님. 이 줄부터 일반 블록으로 처리 (통과)
     }
 
     // 코드블록

--- a/tests/hwpx-equation-generation.test.ts
+++ b/tests/hwpx-equation-generation.test.ts
@@ -1,0 +1,111 @@
+import { describe, it } from "node:test"
+import assert from "node:assert/strict"
+import JSZip from "jszip"
+import { markdownToHwpx, parseHwpx } from "../src/index.js"
+import { generateEquationXml, latexLikeToEqEdit, quoteReservedKeywords } from "../src/hwpx/equation-generate.js"
+import { parseMarkdownToBlocks } from "../src/hwpx/md-runs.js"
+
+const compact = (value: string) => value.replace(/\s+/g, " ").trim()
+
+describe("latexLikeToEqEdit", () => {
+  it("분수, 제곱근, n제곱근을 EqEdit script로 바꾼다", () => {
+    assert.equal(latexLikeToEqEdit("\\frac{a}{b}"), "{a} over {b}")
+    assert.equal(latexLikeToEqEdit("\\sqrt{x}"), "sqrt{x}")
+    assert.equal(latexLikeToEqEdit("\\sqrt[n]{x}"), "root {n} of {x}")
+  })
+
+  it("그리스 문자, 적분, 극한, 화살표, 관계 연산자를 제한된 subset으로 바꾼다", () => {
+    assert.equal(latexLikeToEqEdit("\\alpha + \\beta = \\gamma"), "alpha + beta = gamma")
+    assert.equal(latexLikeToEqEdit("\\int_a^b f(x) dx"), "int _{a} ^{b} f(x) dx")
+    assert.equal(latexLikeToEqEdit("\\lim_{x \\to 0} f(x)"), "lim _{x -> 0} f(x)")
+    assert.equal(latexLikeToEqEdit("A \\rightarrow B"), "A -> B")
+    assert.equal(latexLikeToEqEdit("x \\le y \\ne z \\ge w"), "x LEQ y != z GEQ w")
+  })
+
+  it("matrix 환경을 HWP 행렬 구분자로 바꾼다", () => {
+    const out = latexLikeToEqEdit("\\begin{matrix} a & b \\\\ c & d \\end{matrix}")
+    assert.equal(out, "{matrix{a & b # c & d}}")
+  })
+
+  it("첨자/위첨자 안 짧은 예약어는 따옴표로 보호한다", () => {
+    assert.equal(quoteReservedKeywords("electrode _{rel} ^{infty}"), 'electrode _{"rel"} ^{infty}')
+  })
+})
+
+describe("parseMarkdownToBlocks — display math", () => {
+  it("single-line display math를 equation block으로 파싱한다", () => {
+    const blocks = parseMarkdownToBlocks("$$a+b$$")
+    assert.deepEqual(blocks, [{ type: "equation", text: "a+b" }])
+  })
+
+  it("multi-line display math를 equation block으로 파싱한다", () => {
+    const blocks = parseMarkdownToBlocks("앞\n\n$$\na+b\n$$\n\n뒤")
+    assert.equal(blocks[0].type, "paragraph")
+    assert.equal(blocks[1].type, "equation")
+    assert.equal(blocks[1].text, "a+b")
+    assert.equal(blocks[2].type, "paragraph")
+  })
+})
+
+describe("generateEquationXml", () => {
+  it("<hp:equation>과 <hp:script>를 생성한다", () => {
+    const xml = generateEquationXml("{a} over {b}", { zOrder: 3 })
+    assert.ok(xml.includes('<hp:equation id="2000000004" zOrder="3" numberingType="EQUATION"'))
+    assert.ok(xml.includes('version="Equation Version 60"'))
+    assert.ok(xml.includes('font="HYhwpEQ"'))
+    assert.ok(xml.includes("<hp:shapeComment>수식입니다.</hp:shapeComment>"))
+    assert.ok(xml.includes("<hp:script>{a} over {b}</hp:script>"))
+  })
+
+  it("<hp:script> 내용을 XML-safe하게 escape한다", () => {
+    const xml = generateEquationXml("x < y & z > w")
+    assert.ok(xml.includes("<hp:script>x &lt; y &amp; z &gt; w</hp:script>"))
+  })
+})
+
+describe("markdownToHwpx equation generation", () => {
+  it("display math block을 section0.xml의 native equation으로 렌더링한다", async () => {
+    const buf = await markdownToHwpx("피타고라스\n\n$$\na^2 + b^2 = c^2\n$$")
+    const zip = await JSZip.loadAsync(buf)
+    const section = await zip.file("Contents/section0.xml")!.async("text")
+
+    assert.ok(section.includes("<hp:equation"), "equation 요소 생성")
+    assert.ok(section.includes("<hp:script>a ^{2} + b ^{2} = c ^{2}</hp:script>"), "script 생성")
+    assert.equal((section.match(/<hp:secPr/g) ?? []).length, 1, "secPr는 1회만 생성")
+  })
+
+  it("수식이 첫 블록이면 secPr 전용 더미 문단 뒤에 equation 문단을 둔다", async () => {
+    const buf = await markdownToHwpx("$$\\frac{a}{b}$$")
+    const zip = await JSZip.loadAsync(buf)
+    const section = await zip.file("Contents/section0.xml")!.async("text")
+    const secPrIdx = section.indexOf("<hp:secPr")
+    const equationIdx = section.indexOf("<hp:equation")
+
+    assert.ok(secPrIdx >= 0)
+    assert.ok(equationIdx > secPrIdx, "equation은 secPr 뒤에 위치")
+    assert.ok(section.includes("<hp:script>{a} over {b}</hp:script>"))
+  })
+
+  it("생성된 HWPX를 다시 파싱하면 수식이 Markdown math로 돌아온다", async () => {
+    const buf = await markdownToHwpx("식:\n\n$$\\frac{a}{b}$$\n\n끝")
+    const parsed = await parseHwpx(buf)
+
+    assert.equal(parsed.success, true)
+    if (parsed.success) {
+      const markdown = compact(parsed.markdown)
+      const mathCompact = parsed.markdown.replace(/\s+/g, "")
+      assert.ok(markdown.includes("식:"), markdown)
+      assert.ok(mathCompact.includes("$\\frac{a}{b}$"), parsed.markdown)
+      assert.ok(markdown.includes("끝"), markdown)
+    }
+  })
+
+  it("여러 수식 block은 서로 다른 equation id를 가진다", async () => {
+    const buf = await markdownToHwpx("$$x$$\n\n본문\n\n$$y$$")
+    const zip = await JSZip.loadAsync(buf)
+    const section = await zip.file("Contents/section0.xml")!.async("text")
+    const ids = [...section.matchAll(/<hp:equation id="(\d+)"/g)].map(m => m[1])
+
+    assert.deepEqual(ids, ["2000000001", "2000000003"])
+  })
+})

--- a/tests/hwpx-equation-generation.test.ts
+++ b/tests/hwpx-equation-generation.test.ts
@@ -2,10 +2,15 @@ import { describe, it } from "node:test"
 import assert from "node:assert/strict"
 import JSZip from "jszip"
 import { markdownToHwpx, parseHwpx } from "../src/index.js"
-import { generateEquationXml, latexLikeToEqEdit, quoteReservedKeywords } from "../src/hwpx/equation-generate.js"
+import {
+  COMMAND_MAP, ACCENT_COMMANDS,
+  generateEquationXml, latexLikeToEqEdit, quoteReservedKeywords,
+} from "../src/hwpx/equation-generate.js"
+import { hmlToLatex } from "../src/hwpx/equation.js"
 import { parseMarkdownToBlocks } from "../src/hwpx/md-runs.js"
 
 const compact = (value: string) => value.replace(/\s+/g, " ").trim()
+const noSpace = (value: string) => value.replace(/\s+/g, "")
 
 describe("latexLikeToEqEdit", () => {
   it("분수, 제곱근, n제곱근을 EqEdit script로 바꾼다", () => {
@@ -27,8 +32,109 @@ describe("latexLikeToEqEdit", () => {
     assert.equal(out, "{matrix{a & b # c & d}}")
   })
 
-  it("첨자/위첨자 안 짧은 예약어는 따옴표로 보호한다", () => {
-    assert.equal(quoteReservedKeywords("electrode _{rel} ^{infty}"), 'electrode _{"rel"} ^{infty}')
+  it("pmatrix/bmatrix는 EqEdit 네이티브 토큰으로 낸다 (LEFT/RIGHT 합성 금지 — 리뷰 ·4)", () => {
+    assert.equal(
+      latexLikeToEqEdit("\\begin{pmatrix} a & b \\\\ c & d \\end{pmatrix}"),
+      "{pmatrix{a & b # c & d}}",
+    )
+    assert.equal(latexLikeToEqEdit("\\begin{bmatrix} 1 \\\\ 2 \\end{bmatrix}"), "{bmatrix{1 # 2}}")
+  })
+})
+
+describe("전 토큰 왕복 정합 (리뷰 ·3) — 쓰기 토큰은 읽기(hmlToLatex)로 같은 명령에 되돌아와야 한다", () => {
+  it("COMMAND_MAP 전 항목이 고정점", () => {
+    for (const [cmd, tok] of Object.entries(COMMAND_MAP)) {
+      const latex = hmlToLatex(tok).trim()
+      assert.match(latex, /^\\[A-Za-z]+$/, `\\${cmd} → "${tok}" → "${latex}" — 읽기 미인식`)
+      assert.equal(
+        COMMAND_MAP[latex.slice(1)], tok,
+        `\\${cmd} → "${tok}" → "${latex}" — 재작성 시 다른 토큰`,
+      )
+    }
+  })
+
+  it("ACCENT_COMMANDS 전 항목이 고정점", () => {
+    for (const [cmd, tok] of Object.entries(ACCENT_COMMANDS)) {
+      const latex = hmlToLatex(`${tok} {x}`).trim()
+      const m = /^\\([A-Za-z]+)/.exec(latex)
+      assert.ok(m, `\\${cmd} → "${tok}{x}" → "${latex}" — 읽기 미인식`)
+      assert.equal(
+        ACCENT_COMMANDS[m![1]], tok,
+        `\\${cmd} → "${tok}" → "\\${m![1]}" — 재작성 시 다른 토큰`,
+      )
+    }
+  })
+
+  it("\\pm·\\cdot·\\ast·\\leftarrow 왕복 (리뷰 ·3 실측 케이스)", () => {
+    const script = latexLikeToEqEdit("a \\pm b \\cdot c \\ast d \\leftarrow e")
+    assert.equal(script, "a +- b cdot c AST d larrow e")
+    assert.equal(noSpace(hmlToLatex(script)), "a\\pmb\\cdotc\\astd\\leftarrowe")
+  })
+})
+
+describe("괄호 구분자 왕복 (리뷰 ·4/·7)", () => {
+  it("\\left( \\right)는 공백 분리 토큰으로 나가 왕복이 닫힌다", () => {
+    const script = latexLikeToEqEdit("\\left( x \\right)")
+    assert.equal(script, "LEFT ( x RIGHT )")
+    assert.equal(noSpace(hmlToLatex(script)), "\\left(x\\right)")
+  })
+
+  it("\\left\\{ \\right\\}는 백슬래시 잔재 없이 균형 잡힌다", () => {
+    const script = latexLikeToEqEdit("\\left\\{ x + y \\right\\}")
+    assert.equal(script, "LEFT { x + y RIGHT }")
+    assert.equal(noSpace(hmlToLatex(script)), "\\left\\{x+y\\right\\}")
+  })
+
+  it("pmatrix 왕복이 환경을 보존한다", () => {
+    const script = latexLikeToEqEdit("\\begin{pmatrix} a & b \\\\ c & d \\end{pmatrix}")
+    assert.equal(noSpace(hmlToLatex(script)), "\\begin{pmatrix}a&b\\\\c&d\\end{pmatrix}")
+  })
+})
+
+describe("첨자 예약어 보호 (리뷰 ·8)", () => {
+  it("EqEdit 어휘와 충돌하는 리터럴 첨자만 따옴표로 보호한다", () => {
+    assert.equal(quoteReservedKeywords("T_{int} + x_{rel}"), 'T_{"int"} + x_{rel}')
+    assert.equal(latexLikeToEqEdit("T_{int}"), 'T _{"int"}')
+    assert.equal(latexLikeToEqEdit("x_{rel}"), "x _{rel}")
+  })
+
+  it("변환 산출물(\\pi→pi)은 재따옴표하지 않는다", () => {
+    assert.equal(latexLikeToEqEdit("x_{\\pi}"), "x _{pi}")
+  })
+
+  it("\\text/\\mathrm 리터럴은 따옴표로 나가고 \\text로 되돌아온다", () => {
+    assert.equal(latexLikeToEqEdit("\\text{int}"), '"int"')
+    assert.equal(noSpace(hmlToLatex('T _{"int"}')), "T_{\\text{int}}")
+  })
+
+  it("따옴표가 재파싱 LaTeX로 누수되지 않는다 (실측 재현)", async () => {
+    const buf = await markdownToHwpx("$$T_{int}$$")
+    const parsed = await parseHwpx(buf)
+    assert.equal(parsed.success, true)
+    if (parsed.success) {
+      assert.ok(!parsed.markdown.includes('"'), parsed.markdown)
+      assert.ok(noSpace(parsed.markdown).includes("\\text{int}"), parsed.markdown)
+    }
+  })
+})
+
+describe("악성/기형 입력 가드 (리뷰 ·2)", () => {
+  it("중괄호 폭탄에 스택 오버플로 없이 리터럴 폴백한다", () => {
+    const out = latexLikeToEqEdit("{".repeat(5000))
+    assert.equal(typeof out, "string")
+  })
+
+  it("수식 소스 길이 상한 초과는 변환 없이 통과한다", () => {
+    const long = "x + ".repeat(4000)
+    const out = latexLikeToEqEdit(long)
+    assert.equal(typeof out, "string")
+  })
+
+  it("markdownToHwpx 경유 중괄호 폭탄도 크래시 없다 (실측 재현)", async () => {
+    const buf = await markdownToHwpx("$$" + "{".repeat(30000))
+    assert.ok(buf.byteLength > 0)
+    const closed = await markdownToHwpx("$$\n" + "{".repeat(30000) + "\n$$")
+    assert.ok(closed.byteLength > 0)
   })
 })
 
@@ -45,11 +151,45 @@ describe("parseMarkdownToBlocks — display math", () => {
     assert.equal(blocks[1].text, "a+b")
     assert.equal(blocks[2].type, "paragraph")
   })
+
+  it("닫히지 않은 $$는 문서를 삼키지 않고 일반 문단으로 폴백한다 (리뷰 ·1 실측 재현)", () => {
+    const blocks = parseMarkdownToBlocks("$$100만원 예산 내역\n\n항목1\n\n항목2")
+    assert.deepEqual(blocks.map(b => b.type), ["paragraph", "paragraph", "paragraph"])
+    assert.ok(blocks[0].text!.includes("100만원"))
+  })
+
+  it("같은 줄 닫는 $$ 뒤 텍스트를 문단으로 보존한다 (리뷰 ·1)", () => {
+    const blocks = parseMarkdownToBlocks("$$a+b$$ 이다.")
+    assert.deepEqual(blocks, [
+      { type: "equation", text: "a+b" },
+      { type: "paragraph", text: "이다." },
+    ])
+  })
+
+  it("닫는 줄의 $$ 뒤 텍스트를 무음 소실하지 않는다 (리뷰 ·6 실측 재현)", () => {
+    const blocks = parseMarkdownToBlocks("$$\nx = 1\n$$ 따라서 성립한다.")
+    assert.deepEqual(blocks, [
+      { type: "equation", text: "x = 1" },
+      { type: "paragraph", text: "따라서 성립한다." },
+    ])
+  })
+
+  it("빈 줄/코드펜스 경계에서 멀티라인 수집을 멈춘다", () => {
+    const blocks = parseMarkdownToBlocks("$$\na+b\n\n문단입니다\n\n$$x$$")
+    assert.deepEqual(blocks.map(b => b.type), ["paragraph", "paragraph", "paragraph", "equation"])
+    const fenced = parseMarkdownToBlocks("$$\n```\ncode\n```")
+    assert.equal(fenced.some(b => b.type === "equation"), false)
+  })
+
+  it("이스케이프된 \\$$ 는 수식 여닫이로 세지 않는다 (escapeGfm 접점)", () => {
+    const blocks = parseMarkdownToBlocks("\\$\\$a+b\\$\\$")
+    assert.deepEqual(blocks.map(b => b.type), ["paragraph"])
+  })
 })
 
 describe("generateEquationXml", () => {
   it("<hp:equation>과 <hp:script>를 생성한다", () => {
-    const xml = generateEquationXml("{a} over {b}", { zOrder: 3 })
+    const xml = generateEquationXml("{a} over {b}", 3)
     assert.ok(xml.includes('<hp:equation id="2000000004" zOrder="3" numberingType="EQUATION"'))
     assert.ok(xml.includes('version="Equation Version 60"'))
     assert.ok(xml.includes('font="HYhwpEQ"'))
@@ -74,6 +214,13 @@ describe("markdownToHwpx equation generation", () => {
     assert.equal((section.match(/<hp:secPr/g) ?? []).length, 1, "secPr는 1회만 생성")
   })
 
+  it("수식 문단은 다른 생성 문단과 같은 최소 셸 — lineseg/고정 id 없음", async () => {
+    const buf = await markdownToHwpx("$$a+b$$")
+    const zip = await JSZip.loadAsync(buf)
+    const section = await zip.file("Contents/section0.xml")!.async("text")
+    assert.ok(!section.includes("<hp:linesegarray"), "lineseg는 한컴 재계산에 맡긴다")
+  })
+
   it("수식이 첫 블록이면 secPr 전용 더미 문단 뒤에 equation 문단을 둔다", async () => {
     const buf = await markdownToHwpx("$$\\frac{a}{b}$$")
     const zip = await JSZip.loadAsync(buf)
@@ -93,7 +240,7 @@ describe("markdownToHwpx equation generation", () => {
     assert.equal(parsed.success, true)
     if (parsed.success) {
       const markdown = compact(parsed.markdown)
-      const mathCompact = parsed.markdown.replace(/\s+/g, "")
+      const mathCompact = noSpace(parsed.markdown)
       assert.ok(markdown.includes("식:"), markdown)
       assert.ok(mathCompact.includes("$\\frac{a}{b}$"), parsed.markdown)
       assert.ok(markdown.includes("끝"), markdown)
@@ -107,5 +254,17 @@ describe("markdownToHwpx equation generation", () => {
     const ids = [...section.matchAll(/<hp:equation id="(\d+)"/g)].map(m => m[1])
 
     assert.deepEqual(ids, ["2000000001", "2000000003"])
+  })
+
+  it("공문 모드에서 수식이 항목 번호 run을 끊지 않는다 (리뷰 ·5 실측 재현)", async () => {
+    const md = "1. 첫째 항목\n\n$$a+b$$\n\n2. 둘째 항목\n\n3. 셋째 항목"
+    const buf = await markdownToHwpx(md, { gongmun: { preset: "기안문" } })
+    const zip = await JSZip.loadAsync(buf)
+    const section = await zip.file("Contents/section0.xml")!.async("text")
+
+    assert.ok(section.includes("1. 첫째 항목"), "1번 유지 (단일형제 생략 미발동)")
+    assert.ok(section.includes("2. 둘째 항목"), "수식 뒤 번호 연속")
+    assert.ok(section.includes("3. 셋째 항목"), "run 전체 연속")
+    assert.ok(section.includes("<hp:equation"), "수식도 생성됨")
   })
 })


### PR DESCRIPTION
## 배경

Refs #38

HWPX 안의 기존 `<hp:equation>`을 읽어 Markdown/LaTeX 쪽으로 풀어내는 경로는 이미 있었지만, `markdownToHwpx()`가 Markdown 수식을 native HWPX equation object로 생성하는 경로는 없었습니다.

이번 PR은 display math block `$$ ... $$`를 초기 지원 범위의 native `<hp:equation>`으로 생성하는 첫 단계입니다.

## 바꾼 점

- Markdown display math block을 `equation` block으로 파싱합니다.
- 제한된 LaTeX-like subset을 Hancom EqEdit script로 변환합니다.
- `<hp:equation>` / `<hp:script>` XML 생성 helper를 추가했습니다.
- 수식이 첫 block일 때는 `secPr` 전용 dummy paragraph 뒤에 equation paragraph를 배치합니다.
- README에 현재 지원 범위와 제한을 추가했습니다.
- 수식 생성 helper, block parsing, XML escaping, HWPX structure, parser round-trip smoke 테스트를 추가했습니다.

## 현재 지원 범위

- `\frac{a}{b}`
- `\sqrt{x}`, `\sqrt[n]{x}`
- 첨자/위첨자
- Greek letters
- 적분/극한
- 화살표와 관계 연산자 일부
- `matrix`, `pmatrix`, `bmatrix` 계열의 기본 행렬 변환

## 제한사항

- full LaTeX parser가 아닙니다.
- inline math `$...$`는 아직 지원하지 않습니다.
- HWP 5.x binary equation generation은 건드리지 않았습니다.
- PDF formula OCR/인식 경로는 변경하지 않았습니다.
- 구조/round-trip smoke를 확인했지만, Hancom GUI open 또는 layout parity는 아직 확인하지 않았습니다.

## 확인

- [x] `node --import tsx --test tests/hwpx-equation-generation.test.ts`
- [x] `npm test`
- [x] `npm run build`
- [x] `git diff --check`
- [x] 생성 HWPX `Contents/section0.xml`에 `<hp:equation>` / `<hp:script>` 생성 확인
- [x] 생성 HWPX를 `parseHwpx()`로 다시 읽는 round-trip smoke 확인
- [ ] Windows + Hancom Office에서 샘플 파일 open 확인
