### PR TITLE
[codex] fix(hwpx): reserve line height for tall equations

### DIFF
--- a/src/hwpx/equation-generate.ts
+++ b/src/hwpx/equation-generate.ts
@@ -321,17 +321,25 @@ interface EquationMetrics {
 }
 
 function estimateEquationMetrics(script: string): EquationMetrics {
+  const metricScript = script.replace(/"[^"]*"/g, " ")
   const cleaned = script.replace(/[{}\\^_]/g, "").replace(/\s+/g, " ").trim()
   const width = Math.min(Math.max(cleaned.length, 5) * 700 + 2000, 40000)
   const rowCount = Math.max(1, (script.match(/#/g) ?? []).length + 1)
 
-  if (/\bmatrix\b|#/.test(script)) {
+  if (/\bmatrix\b|#/.test(metricScript)) {
     if (rowCount >= 4) return { width, height: 5500, baseline: 55 }
     if (rowCount === 3) return { width, height: 4500, baseline: 60 }
     return { width, height: 3260, baseline: 63 }
   }
-  if (/\bover\b|\broot\b|\bsqrt\b/.test(script)) return { width, height: 3010, baseline: 69 }
+  if (/\bover\b|\broot\b|\bsqrt\b/.test(metricScript)) return { width, height: 3010, baseline: 69 }
+  if (/\b(?:int|dint|tint|oint|sum|prod|coprod|lim|liminf|limsup|bigcup|bigcap)\b/.test(metricScript)) {
+    return { width, height: 3010, baseline: 69 }
+  }
   return { width, height: 1450, baseline: 71 }
+}
+
+function estimateEquationLineHeight(metrics: EquationMetrics): number {
+  return metrics.height + Math.max(700, Math.round(metrics.height * 0.2))
 }
 
 export function generateEquationXml(script: string, zOrder: number = 0): string {
@@ -353,8 +361,11 @@ export function generateEquationXml(script: string, zOrder: number = 0): string 
 
 export function generateEquationParagraph(input: string, zOrder: number = 0): string {
   const script = latexLikeToEqEdit(input)
-  // 다른 생성 문단과 같은 최소 셸 — lineseg/고정 id 없이 한컴 재계산에 맡긴다
-  // (gen-table.ts 표 래핑과 동일 규약)
+  const metrics = estimateEquationMetrics(script)
+  const lineHeight = estimateEquationLineHeight(metrics)
   return `<hp:p paraPrIDRef="${PARA_NORMAL}" styleIDRef="0">` +
-    `<hp:run charPrIDRef="${CHAR_NORMAL}">${generateEquationXml(script, zOrder)}</hp:run></hp:p>`
+    `<hp:run charPrIDRef="${CHAR_NORMAL}">${generateEquationXml(script, zOrder)}<hp:t/></hp:run>` +
+    `<hp:linesegarray><hp:lineseg textpos="0" vertpos="0" vertsize="${lineHeight}" textheight="${lineHeight}" ` +
+    `baseline="${Math.max(lineHeight - 938, 200)}" spacing="600" horzpos="0" horzsize="42520" flags="393216"/>` +
+    `</hp:linesegarray></hp:p>`
 }

--- a/tests/hwpx-equation-generation.test.ts
+++ b/tests/hwpx-equation-generation.test.ts
@@ -4,7 +4,7 @@ import JSZip from "jszip"
 import { markdownToHwpx, parseHwpx } from "../src/index.js"
 import {
   COMMAND_MAP, ACCENT_COMMANDS,
-  generateEquationXml, latexLikeToEqEdit, quoteReservedKeywords,
+  generateEquationParagraph, generateEquationXml, latexLikeToEqEdit, quoteReservedKeywords,
 } from "../src/hwpx/equation-generate.js"
 import { hmlToLatex } from "../src/hwpx/equation.js"
 import { parseMarkdownToBlocks } from "../src/hwpx/md-runs.js"
@@ -193,6 +193,7 @@ describe("generateEquationXml", () => {
     assert.ok(xml.includes('<hp:equation id="2000000004" zOrder="3" numberingType="EQUATION"'))
     assert.ok(xml.includes('version="Equation Version 60"'))
     assert.ok(xml.includes('font="HYhwpEQ"'))
+    assert.ok(xml.includes('affectLSpacing="0"'))
     assert.ok(xml.includes("<hp:shapeComment>수식입니다.</hp:shapeComment>"))
     assert.ok(xml.includes("<hp:script>{a} over {b}</hp:script>"))
   })
@@ -200,6 +201,43 @@ describe("generateEquationXml", () => {
   it("<hp:script> 내용을 XML-safe하게 escape한다", () => {
     const xml = generateEquationXml("x < y & z > w")
     assert.ok(xml.includes("<hp:script>x &lt; y &amp; z &gt; w</hp:script>"))
+  })
+
+  it("적분/극한처럼 위아래 limit가 붙는 연산자는 큰 수식 높이를 예약한다", () => {
+    const integral = generateEquationXml("int _{a} ^{b} f(x) dx")
+    const limit = generateEquationXml("lim _{x -> 0} f(x)")
+
+    assert.ok(integral.includes('baseLine="69"'))
+    assert.ok(integral.includes('height="3010"'))
+    assert.ok(limit.includes('baseLine="69"'))
+    assert.ok(limit.includes('height="3010"'))
+  })
+
+  it("따옴표 처리된 리터럴 예약어는 tall operator로 오인하지 않는다", () => {
+    const xml = generateEquationXml('T _{"int"}')
+    assert.ok(xml.includes('baseLine="71"'))
+    assert.ok(xml.includes('height="1450"'))
+  })
+})
+
+describe("generateEquationParagraph", () => {
+  it("큰 연산자 수식은 shape보다 큰 lineseg 높이를 예약한다", () => {
+    const xml = generateEquationParagraph("\\int_a^b f(x) dx", 1)
+    const shapeHeight = Number(/<hp:sz[^>]*height="(\d+)"/.exec(xml)?.[1] ?? "0")
+    const textHeight = Number(/<hp:lineseg[^>]*textheight="(\d+)"/.exec(xml)?.[1] ?? "0")
+
+    assert.ok(shapeHeight >= 3000, xml)
+    assert.ok(textHeight >= shapeHeight + 700, xml)
+    assert.ok(!/<hp:p[^>]*\sid=/.test(xml), "문단 고정 id는 추가하지 않는다")
+  })
+
+  it("행렬 수식은 여러 행을 담을 수 있는 lineseg 높이를 예약한다", () => {
+    const xml = generateEquationParagraph("\\begin{pmatrix} a & b \\\\ c & d \\end{pmatrix}", 1)
+    const shapeHeight = Number(/<hp:sz[^>]*height="(\d+)"/.exec(xml)?.[1] ?? "0")
+    const textHeight = Number(/<hp:lineseg[^>]*textheight="(\d+)"/.exec(xml)?.[1] ?? "0")
+
+    assert.ok(shapeHeight >= 3260, xml)
+    assert.ok(textHeight > shapeHeight, xml)
   })
 })
 
@@ -214,11 +252,12 @@ describe("markdownToHwpx equation generation", () => {
     assert.equal((section.match(/<hp:secPr/g) ?? []).length, 1, "secPr는 1회만 생성")
   })
 
-  it("수식 문단은 다른 생성 문단과 같은 최소 셸 — lineseg/고정 id 없음", async () => {
+  it("수식 문단은 후행 빈 텍스트와 lineseg 높이를 가진다", async () => {
     const buf = await markdownToHwpx("$$a+b$$")
     const zip = await JSZip.loadAsync(buf)
     const section = await zip.file("Contents/section0.xml")!.async("text")
-    assert.ok(!section.includes("<hp:linesegarray"), "lineseg는 한컴 재계산에 맡긴다")
+    assert.ok(section.includes("<hp:linesegarray"), "수식 높이를 위한 lineseg를 둔다")
+    assert.ok(section.includes("<hp:t/></hp:run><hp:linesegarray>"), "수식 run 뒤 빈 텍스트 노드 유지")
   })
 
   it("수식이 첫 블록이면 secPr 전용 더미 문단 뒤에 equation 문단을 둔다", async () => {


### PR DESCRIPTION
## Summary

Follow-up to #39. This patch reserves more paragraph line height for tall native HWPX equation objects so integrals, limits, sums, products, and matrices do not collapse into cramped lines in generated documents.

## What changed

- Detect tall operators such as `int`, `sum`, `prod`, `lim`, `bigcup`, and `bigcap` when estimating generated equation metrics.
- Ignore quoted equation literals like `T _{"int"}` during metric detection so text literals are not mistaken for tall operators.
- Add a generated equation paragraph `linesegarray` whose `textheight` is larger than the equation shape height.
- Keep the trailing empty `<hp:t/>` after equation objects.
- Add regression tests for tall operators, quoted literals, integrals, and matrices.

## Validation

- `node --import tsx --test tests\hwpx-equation-generation.test.ts` - 36 pass / 0 fail
- 98-equation HWPX smoke - PASS
- `validate.py` on generated HWPX - VALID
- Visual Probe smoke - PASS
- `npm test` - 664 pass / 0 fail
- `npm run build` - PASS
- `git diff --check` - PASS

## Notes

- This does not add or embed any font files.
- Visual Probe is a browser/rhwp smoke check, not a Hancom GUI or PDF layout parity guarantee.