### PR TITLE
fix(table): 레이아웃 표 해체 시 중첩표 보존 (스펙표 유실 수정)

### DIFF
--- a/src/table/builder.ts
+++ b/src/table/builder.ts
@@ -229,7 +229,17 @@ export function flattenLayoutTables(blocks: IRBlock[]): IRBlock[] {
         // 레이아웃 테이블 → 각 셀을 paragraph 블록으로 분해
         for (let r = 0; r < numRows; r++) {
           for (let c = 0; c < numCols; c++) {
-            const cellText = cells[r]?.[c]?.text?.trim()
+            const cell = cells[r]?.[c]
+            if (!cell) continue
+            // 셀에 구조화 블록(중첩표·이미지·다중문단)이 있으면 재귀 해체로 구조 보존.
+            // 중첩 spec 표(numRows>3)는 해체되지 않고 실제 table 블록으로 살아남는다
+            // (text의 " / " 평탄화 폴백으로만 남아 유실되던 버그 수정). 셀 blocks는
+            // 이미 같은 pageNumber로 생성되므로 그대로 보존된다.
+            if (cell.blocks?.length) {
+              result.push(...flattenLayoutTables(cell.blocks))
+              continue
+            }
+            const cellText = cell.text?.trim()
             if (!cellText) continue
             // 셀 내 줄바꿈을 별도 paragraph로 분리
             for (const line of cellText.split("\n")) {

--- a/tests/flatten-nested-table.test.ts
+++ b/tests/flatten-nested-table.test.ts
@@ -1,0 +1,89 @@
+import { describe, it } from "node:test"
+import assert from "node:assert/strict"
+import { flattenLayoutTables, buildTable } from "../src/table/builder.js"
+import type { IRBlock } from "../src/types.js"
+
+describe("flattenLayoutTables — 중첩표 구조 보존", () => {
+  it("레이아웃 표 해체 시 cell.blocks의 중첩 3×3 표를 실제 table 블록으로 보존", () => {
+    // 중첩 spec 표 (numRows=3 → 레이아웃 휴리스틱에 걸리지 않아 표로 살아남아야 함)
+    const nested = buildTable([
+      [{ text: "h1", colSpan: 1, rowSpan: 1 }, { text: "h2", colSpan: 1, rowSpan: 1 }, { text: "h3", colSpan: 1, rowSpan: 1 }],
+      [{ text: "a1", colSpan: 1, rowSpan: 1 }, { text: "a2", colSpan: 1, rowSpan: 1 }, { text: "a3", colSpan: 1, rowSpan: 1 }],
+      [{ text: "b1", colSpan: 1, rowSpan: 1 }, { text: "b2", colSpan: 1, rowSpan: 1 }, { text: "b3", colSpan: 1, rowSpan: 1 }],
+    ])
+    assert.equal(nested.rows, 3)
+    assert.equal(nested.cols, 3)
+
+    // 외곽 2×1 페이지 레이아웃 표: cell(0,0)=반복 머리말, cell(1,0)=본문(blocks 보유)
+    // cell(1,0).text는 줄바꿈 다량 → 레이아웃 휴리스틱(totalNewlines>5) 트리거
+    const outer: IRBlock = {
+      type: "table",
+      pageNumber: 3,
+      table: {
+        rows: 2,
+        cols: 1,
+        hasHeader: true,
+        cells: [
+          [{ text: "머리말 반복 running header", colSpan: 1, rowSpan: 1 }],
+          [{
+            text: "줄1\n줄2\n줄3\n줄4\n줄5\n줄6\n줄7\n줄8",
+            colSpan: 1,
+            rowSpan: 1,
+            blocks: [
+              { type: "paragraph", text: "셀 본문 문단", pageNumber: 3 },
+              { type: "table", table: nested, pageNumber: 3 },
+            ],
+          }],
+        ],
+      },
+    }
+
+    const flat = flattenLayoutTables([outer])
+
+    // 중첩표가 실제 table 블록으로 보존 (문단으로 해체되지 않음)
+    const tableBlocks = flat.filter(b => b.type === "table" && b.table)
+    assert.equal(tableBlocks.length, 1, "중첩 3×3 표가 실제 table 블록으로 보존되어야 함")
+    const preserved = tableBlocks[0].table!
+    assert.equal(preserved.rows, 3, "보존된 표 행 수")
+    assert.equal(preserved.cols, 3, "보존된 표 열 수")
+    assert.equal(preserved.cells[0][0].text, "h1")
+    assert.equal(preserved.cells[2][2].text, "b3")
+
+    // 표 셀 텍스트가 문단으로 새어나오지 않음 (해체 안 됨의 반증)
+    const paraTexts = flat.filter(b => b.type === "paragraph").map(b => b.text)
+    assert.ok(!paraTexts.includes("h1"), "중첩표 셀이 문단으로 해체되지 않아야 함")
+
+    // blocks 내 문단은 보존, blocks 없는 셀(머리말)은 text-split
+    assert.ok(paraTexts.includes("셀 본문 문단"), "blocks 내 문단 보존")
+    assert.ok(paraTexts.includes("머리말 반복 running header"), "머리말 셀은 text-split")
+
+    // pageNumber 보존
+    const headerPara = flat.find(b => b.type === "paragraph" && b.text === "머리말 반복 running header")
+    assert.equal(headerPara?.pageNumber, 3, "text-split 문단 pageNumber 보존")
+  })
+
+  it("blocks 없는 셀은 기존대로 줄 단위 paragraph로 분해 (회귀 방지)", () => {
+    const outer: IRBlock = {
+      type: "table",
+      pageNumber: 5,
+      table: {
+        rows: 2,
+        cols: 1,
+        hasHeader: true,
+        cells: [
+          [{ text: "머리말", colSpan: 1, rowSpan: 1 }],
+          [{ text: "가\n나\n다\n라\n마\n바\n사", colSpan: 1, rowSpan: 1 }],
+        ],
+      },
+    }
+
+    const flat = flattenLayoutTables([outer])
+
+    assert.ok(flat.every(b => b.type === "paragraph"), "표 블록 없이 모두 문단으로 해체")
+    const texts = flat.map(b => b.text)
+    for (const t of ["머리말", "가", "나", "다", "라", "마", "바", "사"]) {
+      assert.ok(texts.includes(t), `'${t}' 문단 존재`)
+    }
+    assert.ok(flat.every(b => b.pageNumber === 5), "pageNumber 보존")
+  })
+})


### PR DESCRIPTION
## 문제

`flattenLayoutTables()`가 레이아웃 표를 해체할 때 각 셀의 `cell.text`(평문 폴백)만 `\n`으로 분해하고 `cell.blocks`(구조화된 자식 블록)를 **무시**합니다. 그 결과 셀 안에 들어 있던 **중첩 표**가 소실되고, `convertTableToText()`가 만든 `" / "` 조인 평문만 남습니다.

실제 공문서(페이지 전체를 N×1 레이아웃 표로 감싸고, 본문 셀 안에 스펙표를 중첩하는 흔한 한글 문서 구조)에서 재현됩니다:

```
# 해체 전 (기대): 실제 표
| 구 분 | 목표성능 | 비고 |
| --- | --- | --- |
| 데이터 추출 | • Masking 적용 | ... |

# 해체 후 (버그): 평문으로 붕괴
구 분 / 목표성능 / 비고
데이터 추출 / • Masking 적용 / ...
```

## 원인

`src/table/builder.ts`의 `flattenLayoutTables()` 해체 분기가 `cell.text.split("\n")`만 수행. `IRCell.blocks`(중첩표/이미지/다중문단을 구조 그대로 보존하는 필드)를 참조하지 않음.

## 수정

해체 분기에서 `cell.blocks`가 있으면 `cell.text` 분해 대신 **`flattenLayoutTables(cell.blocks)`를 재귀 호출**하여 결과를 emit합니다. 중첩표(행 수 > 3이라 레이아웃 표로 오판되지 않음)는 실제 `type:"table"` 블록으로 살아남고, 중첩 레이아웃 표도 재귀적으로 올바르게 처리됩니다. `cell.blocks`가 없는 셀은 기존 `cell.text` 분해 동작을 그대로 유지합니다.

- 레이아웃 표 **감지 휴리스틱은 변경하지 않음** (numRows≤3 / numCols<4 / newlines>5 / textLen>300). 셀 emit 방식만 변경.
- 재귀 깊이는 파서의 `MAX_NEST_DEPTH=8`로 이미 제한되어 무한재귀 불가.
- `pageNumber`는 셀 자식 블록이 동일 섹션 번호를 상속하므로 자동 보존.

## 테스트 계획

- [x] `npm run build` 성공
- [x] `npm test` — 전체 통과 + 신규 `tests/flatten-nested-table.test.ts` (2 케이스: 중첩표 보존 / blocks 없는 셀의 기존 동작 회귀)
- [x] 실제 공문서 HWP E2E: 스펙표가 GFM/HTML 표로 복원, `" / "` 평문 잔존 0, 나머지 본문·제목·이미지 정상

## 하위 호환

레이아웃 표로 해체되는 표 중 **구조화된 셀 블록을 가진 경우에만** 출력이 달라지며, 이는 정보 손실을 막는 순수 정확도 향상입니다. 라운드트립 표 매핑(`hwp5-patch.ts`)은 IR 표 개수가 늘어나는(바이너리 스캔에 더 근접) 안전한 방향이라 영향 없음.
