### PR TITLE
feat(hwp5): 페이지 레이아웃 표의 반복 러닝 헤더 정리 (opt-in)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,6 +20,7 @@ program
   .option("--format <type>", "출력 형식: markdown (기본) 또는 json", "markdown")
   .option("--no-header-footer", "PDF 머리글/바닥글 자동 제거")
   .option("--formula-ocr", "PDF 수식 OCR 활성화 (MFD+MFR ONNX, 첫 사용 시 모델 ~155MB 자동 다운로드)")
+  .option("--dedupe-headers", "HWP5 레이아웃 표 페이지 반복 러닝 헤더 중복 제거 (기본 off — 붙임별 재번호 오삭제 주의)")
   .option("--silent", "진행 메시지 숨기기")
   .action(async (files: string[], opts) => {
     const validFormats = ["markdown", "json"]
@@ -52,6 +53,7 @@ program
         if (opts.pages) parseOptions.pages = opts.pages as string
         if (opts.headerFooter === false) parseOptions.removeHeaderFooter = false
         if (opts.formulaOcr) parseOptions.formulaOcr = true
+        if (opts.dedupeHeaders) parseOptions.dedupeRunningHeaders = true
         if (!opts.silent) {
           parseOptions.onProgress = (current: number, total: number) => {
             process.stderr.write(`\r[kordoc] ${filePrefix}${fileName} (${format}) [${current}/${total}]`)

--- a/src/hwp5/parser.ts
+++ b/src/hwp5/parser.ts
@@ -13,7 +13,7 @@ import { extractHwp5Images, extractHwp5ImagesLenient } from "./images.js"
 import { decryptViewText } from "./crypto.js"
 import { hwpEquationToLatex } from "./equation.js"
 import { parseLenientCfb, type LenientCfbContainer } from "./cfb-lenient.js"
-import { buildTable, blocksToMarkdown, convertTableToText, flattenLayoutTables, MAX_COLS, MAX_ROWS } from "../table/builder.js"
+import { buildTable, blocksToMarkdown, convertTableToText, flattenLayoutTables, dedupeRunningHeaders, MAX_COLS, MAX_ROWS } from "../table/builder.js"
 import type { CellContext, IRBlock, IRCell, IRTable, DocumentMetadata, InternalParseResult, ParseOptions, ParseWarning, OutlineItem, InlineStyle } from "../types.js"
 import { HEADING_RATIO_H1, HEADING_RATIO_H2, HEADING_RATIO_H3 } from "../types.js"
 import { KordocError, sanitizeHref } from "../utils.js"
@@ -184,7 +184,8 @@ export function parseHwp5Document(buffer: Buffer, options?: ParseOptions): Inter
     : extractHwp5ImagesLenient(lenientCfb!, blocks, warnings)
 
   // 레이아웃 테이블 해체 (heading 감지 전에 수행하여 해체된 텍스트도 heading 감지 대상)
-  const flatBlocks = flattenLayoutTables(blocks)
+  // + 페이지 레이아웃 표에서 페이지마다 반복되던 러닝 헤더 중복 제거
+  const flatBlocks = dedupeRunningHeaders(flattenLayoutTables(blocks))
 
   // 스타일 기반 헤딩 감지
   if (docInfo) {

--- a/src/hwp5/parser.ts
+++ b/src/hwp5/parser.ts
@@ -184,8 +184,16 @@ export function parseHwp5Document(buffer: Buffer, options?: ParseOptions): Inter
     : extractHwp5ImagesLenient(lenientCfb!, blocks, warnings)
 
   // 레이아웃 테이블 해체 (heading 감지 전에 수행하여 해체된 텍스트도 heading 감지 대상)
-  // + 페이지 레이아웃 표에서 페이지마다 반복되던 러닝 헤더 중복 제거
-  const flatBlocks = dedupeRunningHeaders(flattenLayoutTables(blocks))
+  let flatBlocks = flattenLayoutTables(blocks)
+  // 페이지 레이아웃 표의 반복 러닝 헤더 중복 제거 — opt-in (기본 off).
+  // 위치 정보가 없는 HWP5 특성상 정당한 번호매김 반복(붙임별 재번호)까지 오삭제할 수
+  // 있어 옵션이 켜졌을 때만 수행하고, 실제 제거가 있으면 경고로 가시화한다.
+  if (options?.dedupeRunningHeaders) {
+    const deduped = dedupeRunningHeaders(flatBlocks)
+    const removed = flatBlocks.length - deduped.length
+    if (removed > 0) warnings.push({ message: `반복 러닝 헤더 ${removed}개 제거`, code: "HIDDEN_TEXT_FILTERED" })
+    flatBlocks = deduped
+  }
 
   // 스타일 기반 헤딩 감지
   if (docInfo) {

--- a/src/table/builder.ts
+++ b/src/table/builder.ts
@@ -249,6 +249,60 @@ export function flattenLayoutTables(blocks: IRBlock[]): IRBlock[] {
   return result
 }
 
+/** 러닝 헤더 후보 판정 최대 길이 — 긴 본문 문단을 헤더로 오인하지 않도록 */
+const RUNNING_HEADER_MAX_LEN = 40
+/** 러닝 헤더로 판정할 최소 반복 횟수 — 페이지마다 재삽입되는 노이즈만 제거 */
+const RUNNING_HEADER_MIN_FREQ = 3
+
+/** 러닝 헤더 후보 여부 — 짧은 번호매김 섹션 제목("2. 과제 구축 내용")만 */
+function isRunningHeaderCandidate(block: IRBlock): boolean {
+  if (block.type !== "paragraph" && block.type !== "heading") return false
+  const text = block.text?.trim()
+  if (!text || text.length > RUNNING_HEADER_MAX_LEN) return false
+  return /^\d+\.\s/.test(text)
+}
+
+/**
+ * 페이지 레이아웃 표에서 유래한 반복 러닝 헤더 문단 중복 제거 — IRBlock 레벨.
+ *
+ * 배경: 구형 HWP5 문서(군 제안서 등)는 본문 전체를 "페이지 = N×1 표" 사슬로
+ * 구성하고 각 표의 cell(0,0)에 동일한 섹션 헤더("2. 과제 구축 내용")를 반복
+ * 배치한다. flattenLayoutTables가 이 표들을 문단으로 해체하면 같은 헤더가
+ * 페이지마다 1회씩 독립 문단으로 남아 본문 사이에 노이즈로 흩어진다. HWP
+ * 머리말/꼬리말(CTRL_HEAD/CTRL_FOOT)은 applyHeaderFooterEffect에서 이미
+ * dedupe되지만, 본문 레이아웃 표의 러닝 헤더는 그 대상이 아니다.
+ *
+ * 정책(보수적): "짧은 번호매김 섹션 제목"이 정확히 동일 텍스트로 3회 이상
+ * 반복될 때만 최초 1회를 남기고 이후 중복을 제거한다. 비후보 블록과 3회 미만
+ * 후보는 원형 그대로 통과시킨다(본문 삭제 위험 최소화). 위치 무관 — 평탄화된
+ * 블록 스트림 전체를 대상으로 하며, 입력 블록을 변형하지 않고 새 배열을 반환한다.
+ */
+export function dedupeRunningHeaders(blocks: IRBlock[]): IRBlock[] {
+  // Pass 1: 후보 텍스트 빈도 집계
+  const freq = new Map<string, number>()
+  for (const block of blocks) {
+    if (!isRunningHeaderCandidate(block)) continue
+    const text = block.text!.trim()
+    freq.set(text, (freq.get(text) ?? 0) + 1)
+  }
+
+  // Pass 2: 빈도 ≥ 임계값인 후보는 최초 1회만 유지, 이후 중복 제거
+  const seen = new Set<string>()
+  const result: IRBlock[] = []
+  for (const block of blocks) {
+    if (isRunningHeaderCandidate(block)) {
+      const text = block.text!.trim()
+      if ((freq.get(text) ?? 0) >= RUNNING_HEADER_MIN_FREQ) {
+        if (seen.has(text)) continue // 이후 중복 — 제거
+        seen.add(text)
+      }
+    }
+    result.push(block)
+  }
+
+  return result
+}
+
 export function blocksToMarkdown(blocks: IRBlock[]): string {
   const lines: string[] = []
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -149,6 +149,16 @@ export interface ParseOptions {
    * `~/.cache/kordoc/models/pix2text/` 에 SHA-256 검증과 함께 저장된다.
    */
   formulaOcr?: boolean
+  /**
+   * 레이아웃 표 페이지 반복 헤더(러닝 헤더) 정리 휴리스틱 활성화 (기본 false).
+   *
+   * 구형 HWP5 문서가 페이지마다 재삽입한 짧은 번호매김 러닝 헤더
+   * ("2. 과제 구축 내용")를 최초 1회만 남기고 이후 중복을 제거한다.
+   * 다만 페이지 위치 정보가 없는 HWP5 특성상 이 휴리스틱은 정당하게 반복되는
+   * 번호매김 문단(예: 붙임/별지별 재번호 "1. 목적")도 삭제할 수 있어 opt-in 으로
+   * 둔다. 활성 시 제거가 발생하면 HIDDEN_TEXT_FILTERED 경고를 남긴다.
+   */
+  dedupeRunningHeaders?: boolean
 }
 
 // ─── 파싱 경고 ──────────────────────────────────────

--- a/tests/dedupe-running-headers.test.ts
+++ b/tests/dedupe-running-headers.test.ts
@@ -1,0 +1,85 @@
+import { describe, it } from "node:test"
+import assert from "node:assert/strict"
+import { dedupeRunningHeaders } from "../src/table/builder.js"
+import type { IRBlock } from "../src/types.js"
+
+describe("dedupeRunningHeaders", () => {
+  it("4회 반복 러닝 헤더는 최초 1회만 남고 본문은 순서대로 모두 보존", () => {
+    const blocks: IRBlock[] = [
+      { type: "paragraph", text: "2. 과제 구축 내용" },
+      { type: "paragraph", text: "본문 문단 A" },
+      { type: "paragraph", text: "2. 과제 구축 내용" },
+      { type: "paragraph", text: "본문 문단 B" },
+      { type: "paragraph", text: "2. 과제 구축 내용" },
+      { type: "paragraph", text: "본문 문단 C" },
+      { type: "paragraph", text: "2. 과제 구축 내용" },
+      { type: "paragraph", text: "본문 문단 D" },
+    ]
+
+    const result = dedupeRunningHeaders(blocks)
+    const texts = result.map(b => b.text)
+
+    // 러닝 헤더는 정확히 1회
+    assert.equal(texts.filter(t => t === "2. 과제 구축 내용").length, 1)
+    // 본문 문단은 개수·순서 그대로 보존
+    assert.deepEqual(
+      texts.filter(t => t?.startsWith("본문")),
+      ["본문 문단 A", "본문 문단 B", "본문 문단 C", "본문 문단 D"]
+    )
+    // 전체 결과 순서: 최초 헤더 → 본문 A~D
+    assert.deepEqual(texts, [
+      "2. 과제 구축 내용",
+      "본문 문단 A",
+      "본문 문단 B",
+      "본문 문단 C",
+      "본문 문단 D",
+    ])
+  })
+
+  it("2회만 반복되는 헤더는 임계값 미만이라 제거하지 않음", () => {
+    const blocks: IRBlock[] = [
+      { type: "paragraph", text: "1. 과제 개요" },
+      { type: "paragraph", text: "본문" },
+      { type: "paragraph", text: "1. 과제 개요" },
+    ]
+
+    const result = dedupeRunningHeaders(blocks)
+    assert.equal(result.length, 3)
+    assert.equal(result.filter(b => b.text === "1. 과제 개요").length, 2)
+  })
+
+  it("번호매김이 아닌 짧은 반복 문단은 후보가 아니므로 보존 (보수적 판정)", () => {
+    const blocks: IRBlock[] = [
+      { type: "paragraph", text: "개요" },
+      { type: "paragraph", text: "본문 1" },
+      { type: "paragraph", text: "개요" },
+      { type: "paragraph", text: "본문 2" },
+      { type: "paragraph", text: "개요" },
+    ]
+
+    const result = dedupeRunningHeaders(blocks)
+    // "개요"는 번호매김 시그니처가 없어 후보가 아님 → 3회 모두 유지
+    assert.equal(result.filter(b => b.text === "개요").length, 3)
+    assert.equal(result.length, 5)
+  })
+
+  it("입력 배열과 블록을 변형하지 않고 새 배열을 반환", () => {
+    const blocks: IRBlock[] = [
+      { type: "paragraph", text: "3. 과제 추진전략" },
+      { type: "paragraph", text: "본문" },
+      { type: "paragraph", text: "3. 과제 추진전략" },
+      { type: "paragraph", text: "3. 과제 추진전략" },
+    ]
+    const before = JSON.stringify(blocks)
+
+    const result = dedupeRunningHeaders(blocks)
+
+    // 새 배열 (참조 다름)
+    assert.notEqual(result, blocks)
+    // 입력 배열 원형 유지 (길이·내용 불변)
+    assert.equal(blocks.length, 4)
+    assert.equal(JSON.stringify(blocks), before)
+    // 결과는 헤더 1회 + 본문 = 2개
+    assert.equal(result.length, 2)
+  })
+})

--- a/tests/dedupe-running-headers.test.ts
+++ b/tests/dedupe-running-headers.test.ts
@@ -1,7 +1,60 @@
 import { describe, it } from "node:test"
 import assert from "node:assert/strict"
+import { createRequire } from "node:module"
 import { dedupeRunningHeaders } from "../src/table/builder.js"
+import { parseHwp5Document } from "../src/hwp5/parser.js"
+import { TAG_PARA_HEADER, TAG_PARA_TEXT } from "../src/hwp5/record.js"
 import type { IRBlock } from "../src/types.js"
+
+// ─── 합성 HWP5(OLE2) 버퍼 빌더 — parseHwp5Document 옵션 게이팅 검증용 ───
+
+interface CfbDoc { [key: string]: unknown }
+const require = createRequire(import.meta.url)
+const CFB: {
+  utils: { cfb_new(): CfbDoc; cfb_add(cfb: CfbDoc, path: string, data: Buffer): void }
+  write(cfb: CfbDoc, opts: { type: "buffer" }): Buffer
+} = require("cfb")
+
+/** 레코드 직렬화: 4바이트 헤더(tagId 10bit | level 10bit | size 12bit) + data */
+function rec(tagId: number, level: number, data: Buffer): Buffer {
+  const header = Buffer.alloc(4)
+  header.writeUInt32LE((tagId & 0x3ff) | ((level & 0x3ff) << 10) | (data.length << 20), 0)
+  return Buffer.concat([header, data])
+}
+
+function utf16(s: string): Buffer {
+  const buf = Buffer.alloc(s.length * 2)
+  for (let i = 0; i < s.length; i++) buf.writeUInt16LE(s.charCodeAt(i), i * 2)
+  return buf
+}
+
+/** 문단 1개 = PARA_HEADER(문단 헤더) + PARA_TEXT(본문) */
+function paraRecords(text: string): Buffer {
+  return Buffer.concat([rec(TAG_PARA_HEADER, 0, Buffer.alloc(12)), rec(TAG_PARA_TEXT, 1, utf16(text))])
+}
+
+/** 문단 텍스트 배열 → 비압축 HWP5 버퍼 (FileHeader + BodyText/Section0) */
+function buildSyntheticHwp5(texts: string[]): Buffer {
+  const fileHeader = Buffer.alloc(256)
+  fileHeader.write("HWP Document File", 0, "utf8")
+  fileHeader[35] = 5 // versionMajor
+  fileHeader.writeUInt32LE(0, 36) // flags: 비압축·비암호화·비배포
+  const section0 = Buffer.concat(texts.map(paraRecords))
+  const cfb = CFB.utils.cfb_new()
+  CFB.utils.cfb_add(cfb, "/FileHeader", fileHeader)
+  CFB.utils.cfb_add(cfb, "/BodyText/Section0", section0)
+  return Buffer.from(CFB.write(cfb, { type: "buffer" }))
+}
+
+/** "붙임/별지별 재번호" 시나리오 — 서로 다른 본문 사이 '1. 목적' 3회(freq 3) */
+const BUNDLED_APPENDICES_TEXTS = [
+  "1. 목적",
+  "가. 첫째 붙임 본문",
+  "1. 목적",
+  "나. 둘째 붙임 본문",
+  "1. 목적",
+  "다. 셋째 붙임 본문",
+]
 
 describe("dedupeRunningHeaders", () => {
   it("4회 반복 러닝 헤더는 최초 1회만 남고 본문은 순서대로 모두 보존", () => {
@@ -81,5 +134,46 @@ describe("dedupeRunningHeaders", () => {
     assert.equal(JSON.stringify(blocks), before)
     // 결과는 헤더 1회 + 본문 = 2개
     assert.equal(result.length, 2)
+  })
+
+  it("번들 붙임(붙임별 재번호) — raw 함수는 2·3번째 '1. 목적'을 오삭제 (알려진 휴리스틱 한계)", () => {
+    // 세 붙임이 각각 독립적으로 '1. 목적'으로 시작(freq 3)하지만, raw 함수는
+    // 페이지 위치 정보가 없어 이를 러닝 헤더와 구분하지 못하고 2·3번째를 삭제한다.
+    // 이 실제 콘텐츠 오삭제가 파이프라인 기본값이 아닌 opt-in으로 게이팅하는 근거다.
+    const blocks: IRBlock[] = BUNDLED_APPENDICES_TEXTS.map(text => ({ type: "paragraph", text }))
+    const result = dedupeRunningHeaders(blocks)
+    const texts = result.map(b => b.text)
+
+    // '1. 목적'은 최초 1회만 남음 — 2·3번째 붙임 헤더 소실 (정당한 콘텐츠 삭제)
+    assert.equal(texts.filter(t => t === "1. 목적").length, 1)
+    // 본문 3개는 순서대로 보존 — 동작이 결정론적·예측가능함을 고정
+    assert.deepEqual(
+      texts.filter(t => t !== "1. 목적"),
+      ["가. 첫째 붙임 본문", "나. 둘째 붙임 본문", "다. 셋째 붙임 본문"]
+    )
+    // 전체 결과: 최초 '1. 목적' + 본문 3개 = 4블록
+    assert.deepEqual(texts, ["1. 목적", "가. 첫째 붙임 본문", "나. 둘째 붙임 본문", "다. 셋째 붙임 본문"])
+  })
+})
+
+describe("parseHwp5Document — dedupeRunningHeaders 옵션 게이팅", () => {
+  it("기본값(옵션 없음) — 아무것도 제거하지 않음: 반복 '1. 목적' 3회 모두 보존, 경고 없음", () => {
+    const buffer = buildSyntheticHwp5(BUNDLED_APPENDICES_TEXTS)
+    const result = parseHwp5Document(buffer)
+
+    // 기본 파이프라인은 flattenLayoutTables만 적용 — dedupe 미수행
+    assert.equal(result.blocks.filter(b => b.text === "1. 목적").length, 3)
+    const filtered = (result.warnings ?? []).filter(w => w.code === "HIDDEN_TEXT_FILTERED")
+    assert.equal(filtered.length, 0)
+  })
+
+  it("dedupeRunningHeaders:true — 최초 1회만 남기고 제거 + HIDDEN_TEXT_FILTERED 경고", () => {
+    const buffer = buildSyntheticHwp5(BUNDLED_APPENDICES_TEXTS)
+    const result = parseHwp5Document(buffer, { dedupeRunningHeaders: true })
+
+    assert.equal(result.blocks.filter(b => b.text === "1. 목적").length, 1)
+    const filtered = (result.warnings ?? []).filter(w => w.code === "HIDDEN_TEXT_FILTERED")
+    assert.equal(filtered.length, 1)
+    assert.match(filtered[0].message, /반복 러닝 헤더 2개 제거/)
   })
 })


### PR DESCRIPTION
## 문제

구형 HWP5 공문서는 페이지마다 짧은 번호매김 러닝 헤더("2. 과제 구축 내용")를 재삽입하는 경우가 많습니다. 이 문서들이 "페이지 = N×1 레이아웃 표" 구조일 때, 표 해체 후 러닝 헤더가 **페이지 수만큼 반복되는 문단**이 되어 본문 사이에 노이즈로 섞입니다(실측: 동일 헤더 6~7회 반복). HWP5의 진짜 머리말/꼬리말 컨트롤(`CTRL_HEAD/FOOT`)은 이미 dedup되지만, 레이아웃 표 안의 러닝 헤더는 대상이 아닙니다.

## 수정

`dedupeRunningHeaders(blocks)`를 추가하여 반복 러닝 헤더를 정리합니다. **opt-in(기본 off)** 설계입니다:

- 후보: `paragraph`/`heading` 중 트림 텍스트가 짧고(≤40자) `^\d+\.\s` 패턴에 맞는 블록
- 2-pass: 후보의 정확 텍스트 빈도를 세고, 빈도 ≥3인 후보의 **첫 등장만** 남기고 이후 중복 제거. 나머지 블록은 순서·내용 그대로 통과. 입력 불변(새 배열 반환).
- `ParseOptions.dedupeRunningHeaders`(기본 false) / CLI `--dedupe-headers`로 활성. 활성 시 제거가 발생하면 `HIDDEN_TEXT_FILTERED` 경고로 제거 건수 보고.

### 왜 opt-in인가

HWP5는 페이지 위치 정보를 섹션으로 접어버리므로, "페이지마다 반복된 러닝 헤더"와 "정당하게 반복되는 번호매김 문단"(예: 붙임/별지별로 각각 `1. 목적`부터 재번호)을 구분할 수 없습니다. 무조건 적용하면 후자의 진짜 섹션 헤더도 삭제될 수 있어, **명시적 opt-in + 제거 경고**로 안전하게 두었습니다. 기본 동작은 아무것도 제거하지 않습니다.

## 테스트 계획

- [x] `npm run build` 성공
- [x] `npm test` — 전체 통과 + 신규 `tests/dedupe-running-headers.test.ts`
- [x] 실제 공문서 HWP E2E: 기본(무플래그) 시 헤더 7회 그대로 유지(제거 0) / `--dedupe-headers` 시 반복 5개 제거 + 경고, 본문 콘텐츠 무손실

## 하위 호환

옵션 미지정 시 출력은 이 기능 도입 전과 동일(byte-identical). HWP5 경로에만 적용, 다른 포맷 무영향.

## 알려진 한계

일부 러닝 헤더 복사본이 `flattenLayoutTables`가 해체하지 않는 단일컬럼 다행(>3행) 표 안에 남아 문단 기반 dedup의 시야 밖입니다(예: 7→2회까지만 감소). 완전 제거는 별도 접근(구조/위치 기반)이 필요해 이 PR 범위에서는 보수적으로 두었습니다.
