### PR TITLE
feat(image): BMP→PNG 압축 base64 이미지 인라인 (--inline-images)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,6 +20,7 @@ program
   .option("--format <type>", "출력 형식: markdown (기본) 또는 json", "markdown")
   .option("--no-header-footer", "PDF 머리글/바닥글 자동 제거")
   .option("--formula-ocr", "PDF 수식 OCR 활성화 (MFD+MFR ONNX, 첫 사용 시 모델 ~155MB 자동 다운로드)")
+  .option("--inline-images", "이미지를 base64 data URI 로 마크다운에 인라인 (BMP→PNG 압축, 별도 파일 미저장)")
   .option("--silent", "진행 메시지 숨기기")
   .action(async (files: string[], opts) => {
     const validFormats = ["markdown", "json"]
@@ -52,6 +53,7 @@ program
         if (opts.pages) parseOptions.pages = opts.pages as string
         if (opts.headerFooter === false) parseOptions.removeHeaderFooter = false
         if (opts.formulaOcr) parseOptions.formulaOcr = true
+        if (opts.inlineImages) parseOptions.inlineImages = true
         if (!opts.silent) {
           parseOptions.onProgress = (current: number, total: number) => {
             process.stderr.write(`\r[kordoc] ${filePrefix}${fileName} (${format}) [${current}/${total}]`)
@@ -69,8 +71,8 @@ program
         if (!opts.silent) process.stderr.write(` OK\n`)
 
         let markdown = result.markdown
-        // --out-dir 시 이미지 참조 경로에 images/ 접두사 추가
-        if (opts.outDir && result.images?.length) {
+        // --out-dir 시 이미지 참조 경로에 images/ 접두사 추가 (인라인 모드에선 이미지가 마크다운에 임베드되므로 건너뜀)
+        if (opts.outDir && result.images?.length && !opts.inlineImages) {
           markdown = markdown.replace(/!\[image\]\(image_/g, "![image](images/image_")
         }
         const output = opts.format === "json"
@@ -79,9 +81,9 @@ program
             , 2)
           : markdown
 
-        // 이미지 저장 (--out-dir 또는 --output 시)
+        // 이미지 저장 (--out-dir 또는 --output 시) — 인라인 모드에선 이미지가 마크다운에 임베드되므로 미저장
         const saveImages = (dir: string) => {
-          if (!result.images?.length) return
+          if (!result.images?.length || opts.inlineImages) return
           const imgDir = resolve(dir, "images")
           mkdirSync(imgDir, { recursive: true })
           for (const img of result.images) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -71,8 +71,12 @@ program
         if (!opts.silent) process.stderr.write(` OK\n`)
 
         let markdown = result.markdown
+        // 이미지 인라인은 HWP5 경로에서만 실제로 일어난다(parser.ts). 그 외 포맷(HWPX/DOCX 등)은
+        // --inline-images 를 줘도 인라인되지 않으므로, 이미지 저장/경로접두사를 생략하면 참조가
+        // 깨지고(dangling) 바이트가 유실된다 → 실제 인라인된 경우에만 생략한다.
+        const imagesInlined = opts.inlineImages && result.fileType === "hwp"
         // --out-dir 시 이미지 참조 경로에 images/ 접두사 추가 (인라인 모드에선 이미지가 마크다운에 임베드되므로 건너뜀)
-        if (opts.outDir && result.images?.length && !opts.inlineImages) {
+        if (opts.outDir && result.images?.length && !imagesInlined) {
           markdown = markdown.replace(/!\[image\]\(image_/g, "![image](images/image_")
         }
         const output = opts.format === "json"
@@ -81,9 +85,9 @@ program
             , 2)
           : markdown
 
-        // 이미지 저장 (--out-dir 또는 --output 시) — 인라인 모드에선 이미지가 마크다운에 임베드되므로 미저장
+        // 이미지 저장 (--out-dir 또는 --output 시) — 실제 인라인된 경우(HWP5)에만 미저장, 그 외엔 저장 유지
         const saveImages = (dir: string) => {
-          if (!result.images?.length || opts.inlineImages) return
+          if (!result.images?.length || imagesInlined) return
           const imgDir = resolve(dir, "images")
           mkdirSync(imgDir, { recursive: true })
           for (const img of result.images) {

--- a/src/hwp5/parser.ts
+++ b/src/hwp5/parser.ts
@@ -200,7 +200,13 @@ export function parseHwp5Document(buffer: Buffer, options?: ParseOptions): Inter
   let markdown = blocksToMarkdown(flatBlocks)
   // 이미지 인라인 옵션 — BMP→PNG 압축 후 base64 data URI 로 치환 (AI 에이전트 자체 완결형 마크다운)
   if (options?.inlineImages && images.length > 0) {
-    markdown = inlineImagesIntoMarkdown(markdown, images, { compress: true })
+    try {
+      markdown = inlineImagesIntoMarkdown(markdown, images, { compress: true })
+    } catch (inlineErr) {
+      // 설계 계약상 bmpToPng 는 실패 시 null 을 반환하지만, 극단 입력·Node 버전차로 할당이
+      // throw 하면 전체 파싱이 죽지 않도록 원본(비인라인) 마크다운을 유지하고 경고만 남긴다.
+      warnings.push({ message: `이미지 인라인 실패 — 원본 파일 참조로 폴백: ${inlineErr instanceof Error ? inlineErr.message : "알 수 없는 오류"}`, code: "SKIPPED_IMAGE" })
+    }
   }
   return { markdown, blocks: flatBlocks, metadata, outline: outline.length > 0 ? outline : undefined, warnings: warnings.length > 0 ? warnings : undefined, images: images.length > 0 ? images : undefined }
 }

--- a/src/hwp5/parser.ts
+++ b/src/hwp5/parser.ts
@@ -10,6 +10,7 @@ import {
 } from "./record.js"
 import { NumberingState, expandNumberingFormat, formatNumber, shapeFormatToNumFmt } from "./numbering.js"
 import { extractHwp5Images, extractHwp5ImagesLenient } from "./images.js"
+import { inlineImagesIntoMarkdown } from "../image/transcode.js"
 import { decryptViewText } from "./crypto.js"
 import { hwpEquationToLatex } from "./equation.js"
 import { parseLenientCfb, type LenientCfbContainer } from "./cfb-lenient.js"
@@ -196,7 +197,11 @@ export function parseHwp5Document(buffer: Buffer, options?: ParseOptions): Inter
     .filter(b => b.type === "heading" && b.level && b.text)
     .map(b => ({ level: b.level!, text: b.text!, pageNumber: b.pageNumber }))
 
-  const markdown = blocksToMarkdown(flatBlocks)
+  let markdown = blocksToMarkdown(flatBlocks)
+  // 이미지 인라인 옵션 — BMP→PNG 압축 후 base64 data URI 로 치환 (AI 에이전트 자체 완결형 마크다운)
+  if (options?.inlineImages && images.length > 0) {
+    markdown = inlineImagesIntoMarkdown(markdown, images, { compress: true })
+  }
   return { markdown, blocks: flatBlocks, metadata, outline: outline.length > 0 ? outline : undefined, warnings: warnings.length > 0 ? warnings : undefined, images: images.length > 0 ? images : undefined }
 }
 

--- a/src/image/transcode.ts
+++ b/src/image/transcode.ts
@@ -38,6 +38,12 @@ function crc32(bytes: Uint8Array): number {
 const BI_RGB = 0
 /** 폭·높이 상한 — 비정상 헤더에 의한 과대 할당 방지 */
 const MAX_DIM = 0x7fff
+/**
+ * 총 픽셀(W×H) 상한 — MAX_DIM 은 각 변만 제한하므로 곱의 폭주(과대 할당 + 긴 deflateSync
+ * 동기 블로킹)를 별도로 차단한다. raw 저장 BMP 는 상위 inflate 100MB 캡을 우회하므로 필요.
+ * ~64MP 는 실제 문서 임베드 이미지보다 훨씬 크다.
+ */
+const MAX_PIXELS = 64_000_000
 
 /**
  * 비압축 BMP(24/32bpp, BI_RGB) → PNG(8bit RGBA).
@@ -69,6 +75,8 @@ export function bmpToPng(bmp: Uint8Array): Uint8Array | null {
 
   const topDown = rawHeight < 0
   const height = Math.abs(rawHeight)
+  // 총 픽셀 상한 검사 — rgba/raw 할당·deflate 전에 조기 차단 (각 변은 MAX_DIM 이하여도 곱은 폭주 가능)
+  if (width * height > MAX_PIXELS) return null
   const bytesPerPixel = bitCount >> 3
   // 행 스트라이드 — 4바이트 경계 패딩 (24bpp 에서 유효)
   const rowStride = (width * bytesPerPixel + 3) & ~3
@@ -158,6 +166,13 @@ function encodePng(width: number, height: number, rgba: Uint8Array): Uint8Array 
 }
 
 // ─── 마크다운 이미지 인라이너 ────────────────────────
+
+/**
+ * 인라인 마크다운 바이트 상한(4MB) — MCP `parse_document` 가 이미지 다수 문서를
+ * 인라인할 때 base64 폭증으로 에이전트 컨텍스트/전송을 넘기지 않도록 하는 폴백 기준.
+ * 초과 시 비인라인(파일 참조) 출력으로 되돌린다.
+ */
+export const MAX_INLINE_MD_BYTES = 4 * 1024 * 1024
 
 /** 정규식 메타문자 이스케이프 */
 function escapeRegExp(s: string): string {

--- a/src/image/transcode.ts
+++ b/src/image/transcode.ts
@@ -1,0 +1,205 @@
+/**
+ * 순수 JS BMP → PNG 트랜스코더 + 마크다운 이미지 인라이너.
+ *
+ * HWP5 BinData 임베드 이미지는 비압축 BMP(수 MB)인 경우가 많다. AI 에이전트가
+ * 자체 완결형 마크다운을 받도록, BMP 를 PNG(무손실 압축)로 변환한 뒤 base64
+ * data URI 로 마크다운에 인라인한다.
+ *
+ * 의존성 최소화 원칙 — Node 내장(node:zlib, Buffer)만 사용한다.
+ */
+
+import { deflateSync } from "node:zlib"
+
+// ─── CRC32 (PNG 청크용) ──────────────────────────────
+
+const CRC_TABLE = (() => {
+  const table = new Uint32Array(256)
+  for (let n = 0; n < 256; n++) {
+    let c = n
+    for (let k = 0; k < 8; k++) {
+      c = (c & 1) ? (0xedb88320 ^ (c >>> 1)) : (c >>> 1)
+    }
+    table[n] = c >>> 0
+  }
+  return table
+})()
+
+/** 표준 PNG CRC32 (다항식 0xEDB88320) */
+function crc32(bytes: Uint8Array): number {
+  let c = 0xffffffff
+  for (let i = 0; i < bytes.length; i++) {
+    c = CRC_TABLE[(c ^ bytes[i]) & 0xff] ^ (c >>> 8)
+  }
+  return (c ^ 0xffffffff) >>> 0
+}
+
+// ─── BMP 디코드 ──────────────────────────────────────
+
+const BI_RGB = 0
+/** 폭·높이 상한 — 비정상 헤더에 의한 과대 할당 방지 */
+const MAX_DIM = 0x7fff
+
+/**
+ * 비압축 BMP(24/32bpp, BI_RGB) → PNG(8bit RGBA).
+ *
+ * 지원: BITMAPFILEHEADER + BITMAPINFOHEADER(biSize>=40), biBitCount 24/32,
+ * biCompression BI_RGB, bottom-up(양수 biHeight)/top-down(음수), 24bpp 4바이트 행 패딩.
+ * 미지원 변형(팔레트/8bpp·RLE·BITFIELDS·OS/2 헤더 등)은 null 을 반환하여
+ * 호출부가 원본 바이트로 폴백하게 한다.
+ */
+export function bmpToPng(bmp: Uint8Array): Uint8Array | null {
+  // BITMAPFILEHEADER(14) + BITMAPINFOHEADER(40)
+  if (bmp.length < 54) return null
+  if (bmp[0] !== 0x42 || bmp[1] !== 0x4d) return null // "BM"
+
+  const dv = new DataView(bmp.buffer, bmp.byteOffset, bmp.byteLength)
+  const dataOffset = dv.getUint32(10, true)
+  const headerSize = dv.getUint32(14, true)
+  if (headerSize < 40) return null // OS/2 BITMAPCOREHEADER 등 미지원
+
+  const width = dv.getInt32(18, true)
+  const rawHeight = dv.getInt32(22, true)
+  const bitCount = dv.getUint16(28, true)
+  const compression = dv.getUint32(30, true)
+
+  if (compression !== BI_RGB) return null // RLE / BITFIELDS 미지원
+  if (bitCount !== 24 && bitCount !== 32) return null // 팔레트 / 8bpp 등 미지원
+  if (width <= 0 || rawHeight === 0) return null
+  if (width > MAX_DIM || Math.abs(rawHeight) > MAX_DIM) return null
+
+  const topDown = rawHeight < 0
+  const height = Math.abs(rawHeight)
+  const bytesPerPixel = bitCount >> 3
+  // 행 스트라이드 — 4바이트 경계 패딩 (24bpp 에서 유효)
+  const rowStride = (width * bytesPerPixel + 3) & ~3
+  if (dataOffset + rowStride * height > bmp.length) return null // 잘린 파일
+
+  const rgba = new Uint8Array(width * height * 4)
+  let anyAlpha = 0
+
+  for (let y = 0; y < height; y++) {
+    // bottom-up 은 첫 행이 이미지 맨 아래 → 뒤집어 읽는다
+    const srcRow = topDown ? y : height - 1 - y
+    let src = dataOffset + srcRow * rowStride
+    let dst = y * width * 4
+    for (let x = 0; x < width; x++) {
+      // BMP 픽셀은 BGR(A) 순
+      rgba[dst] = bmp[src + 2]     // R
+      rgba[dst + 1] = bmp[src + 1] // G
+      rgba[dst + 2] = bmp[src]     // B
+      const a = bitCount === 32 ? bmp[src + 3] : 255
+      rgba[dst + 3] = a
+      anyAlpha |= a
+      src += bytesPerPixel
+      dst += 4
+    }
+  }
+
+  // 32bpp BI_RGB 의 4번째 바이트는 "미정의" — 전부 0 이면 전면 투명으로 오해되므로
+  // 불투명(255)으로 승격한다. 실제 알파가 있으면(anyAlpha!=0) 그대로 보존.
+  if (bitCount === 32 && anyAlpha === 0) {
+    for (let i = 3; i < rgba.length; i += 4) rgba[i] = 255
+  }
+
+  return encodePng(width, height, rgba)
+}
+
+// ─── PNG 인코드 (8bit RGBA, color type 6) ────────────
+
+const PNG_SIGNATURE = Uint8Array.of(0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a)
+
+/** [4B 길이][4B 타입][데이터][4B CRC] 청크 조립. CRC 는 (타입+데이터) 기준. */
+function chunk(type: string, data: Uint8Array): Uint8Array {
+  const body = new Uint8Array(4 + data.length)
+  body[0] = type.charCodeAt(0)
+  body[1] = type.charCodeAt(1)
+  body[2] = type.charCodeAt(2)
+  body[3] = type.charCodeAt(3)
+  body.set(data, 4)
+
+  const out = new Uint8Array(8 + data.length + 4)
+  const dv = new DataView(out.buffer)
+  dv.setUint32(0, data.length, false) // 길이(데이터만, big-endian)
+  out.set(body, 4)
+  dv.setUint32(8 + data.length, crc32(body), false)
+  return out
+}
+
+function encodePng(width: number, height: number, rgba: Uint8Array): Uint8Array {
+  // IHDR: width, height, bit depth 8, color type 6(RGBA), compression 0, filter 0, interlace 0
+  const ihdr = new Uint8Array(13)
+  const iv = new DataView(ihdr.buffer)
+  iv.setUint32(0, width, false)
+  iv.setUint32(4, height, false)
+  ihdr[8] = 8
+  ihdr[9] = 6
+
+  // IDAT: 각 스캔라인 앞에 필터 바이트 0(None) 을 붙인 raw 데이터를 zlib deflate
+  const stride = width * 4
+  const raw = new Uint8Array((stride + 1) * height)
+  for (let y = 0; y < height; y++) {
+    const rowStart = y * (stride + 1)
+    raw[rowStart] = 0 // filter: None
+    raw.set(rgba.subarray(y * stride, y * stride + stride), rowStart + 1)
+  }
+  const idat = deflateSync(raw)
+
+  const ihdrChunk = chunk("IHDR", ihdr)
+  const idatChunk = chunk("IDAT", idat)
+  const iendChunk = chunk("IEND", new Uint8Array(0))
+
+  const out = new Uint8Array(PNG_SIGNATURE.length + ihdrChunk.length + idatChunk.length + iendChunk.length)
+  let o = 0
+  out.set(PNG_SIGNATURE, o); o += PNG_SIGNATURE.length
+  out.set(ihdrChunk, o); o += ihdrChunk.length
+  out.set(idatChunk, o); o += idatChunk.length
+  out.set(iendChunk, o)
+  return out
+}
+
+// ─── 마크다운 이미지 인라이너 ────────────────────────
+
+/** 정규식 메타문자 이스케이프 */
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}
+
+interface InlineImage {
+  filename: string
+  data: Uint8Array
+  mimeType: string
+}
+
+/**
+ * 마크다운의 `![image](FILENAME)` 및 `![image](images/FILENAME)`(CLI 접두사) 참조를
+ * base64 data URI 로 치환한다. 별도 이미지 파일 없이 자체 완결형 마크다운이 되어
+ * MCP/AI 에이전트 소비에 적합하다.
+ *
+ * @param opts.compress 기본 true. `image/bmp` 는 PNG 로 트랜스코딩 후 인라인하며,
+ *                      트랜스코딩 실패 시 원본 바이트+원본 MIME 으로 폴백한다.
+ */
+export function inlineImagesIntoMarkdown(
+  markdown: string,
+  images: ReadonlyArray<InlineImage>,
+  opts?: { compress?: boolean },
+): string {
+  const compress = opts?.compress !== false
+  let out = markdown
+  for (const img of images) {
+    let bytes = img.data
+    let mime = img.mimeType
+    if (compress && mime === "image/bmp") {
+      const png = bmpToPng(img.data)
+      if (png) {
+        bytes = png
+        mime = "image/png"
+      }
+    }
+    const base64 = Buffer.from(bytes).toString("base64")
+    const dataUri = `data:${mime};base64,${base64}`
+    // FILENAME 과 images/FILENAME 접두사를 모두 정확한 파일명 기준으로 치환
+    const re = new RegExp(`!\\[image\\]\\((?:images/)?${escapeRegExp(img.filename)}\\)`, "g")
+    out = out.replace(re, () => `![image](${dataUri})`)
+  }
+  return out
+}

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -98,7 +98,8 @@ server.tool(
         }
       }
 
-      const result = await parse(buffer)
+      // 에이전트가 별도 파일 없이 이미지를 해석하도록 자체 완결형 마크다운(이미지 인라인)을 기본 제공
+      const result = await parse(buffer, { inlineImages: true })
 
       if (!result.success) {
         return {

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -11,6 +11,7 @@ import type { GongmunOptions } from "./index.js"
 import { VERSION, toArrayBuffer, sanitizeError, KordocError } from "./utils.js"
 import { extractHwp5MetadataOnly } from "./hwp5/parser.js"
 import { extractHwpxMetadataOnly } from "./hwpx/parser.js"
+import { MAX_INLINE_MD_BYTES } from "./image/transcode.js"
 // pdfjs-dist는 optional — dynamic import로 지연 로드
 // import { extractPdfMetadataOnly } from "./pdf/parser.js"
 
@@ -108,6 +109,17 @@ server.tool(
         }
       }
 
+      // 인라인 결과가 상한을 넘으면(이미지 다수 → base64 폭증) 에이전트 컨텍스트/전송 오버플로를
+      // 막기 위해 비인라인(파일 참조) 마크다운으로 폴백하고, 생략 사실을 안내한다. (재파싱 대신
+      // 이미 파싱된 blocks 로 마크다운만 재생성 — blocks 의 이미지 참조는 인라인으로 바뀌지 않음)
+      let markdown = result.markdown
+      let omitNote = ""
+      if (Buffer.byteLength(markdown, "utf8") > MAX_INLINE_MD_BYTES) {
+        markdown = blocksToMarkdown(result.blocks)
+        const imgCount = result.images?.length ?? 0
+        omitNote = `\n\n⚠️ 이미지 ${imgCount}개가 인라인 크기 상한(${(MAX_INLINE_MD_BYTES / 1024 / 1024).toFixed(0)}MB)을 초과하여 본문에 인라인하지 않았습니다. 이미지는 파일 참조(image_NNN)로만 표시됩니다.`
+      }
+
       const meta = [
         `포맷: ${result.fileType.toUpperCase()}`,
         result.pageCount ? `페이지: ${result.pageCount}` : null,
@@ -129,7 +141,8 @@ server.tool(
         parts.push(`\n⚠️ 경고:\n${warnText}`)
       }
 
-      parts.push(`\n\n${result.markdown}`)
+      parts.push(`\n\n${markdown}`)
+      if (omitNote) parts.push(omitNote)
 
       return {
         content: [{ type: "text", text: parts.join("") }],

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -112,11 +112,15 @@ server.tool(
       // 인라인 결과가 상한을 넘으면(이미지 다수 → base64 폭증) 에이전트 컨텍스트/전송 오버플로를
       // 막기 위해 비인라인(파일 참조) 마크다운으로 폴백하고, 생략 사실을 안내한다. (재파싱 대신
       // 이미 파싱된 blocks 로 마크다운만 재생성 — blocks 의 이미지 참조는 인라인으로 바뀌지 않음)
+      // 인라인은 HWP5 이미지 경로에서만 일어나므로, 실제 인라인된 경우에 한해 폴백한다 — 그 외
+      // 포맷의 대용량 '텍스트' 는 정상 출력이며 blocksToMarkdown 재생성은 포맷별 후처리(PDF
+      // cleanPdfText 등)를 잃으므로 건드리지 않는다.
       let markdown = result.markdown
       let omitNote = ""
-      if (Buffer.byteLength(markdown, "utf8") > MAX_INLINE_MD_BYTES) {
+      const imgCount = result.images?.length ?? 0
+      const didInline = result.fileType === "hwp" && imgCount > 0
+      if (didInline && Buffer.byteLength(markdown, "utf8") > MAX_INLINE_MD_BYTES) {
         markdown = blocksToMarkdown(result.blocks)
-        const imgCount = result.images?.length ?? 0
         omitNote = `\n\n⚠️ 이미지 ${imgCount}개가 인라인 크기 상한(${(MAX_INLINE_MD_BYTES / 1024 / 1024).toFixed(0)}MB)을 초과하여 본문에 인라인하지 않았습니다. 이미지는 파일 참조(image_NNN)로만 표시됩니다.`
       }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -149,6 +149,15 @@ export interface ParseOptions {
    * `~/.cache/kordoc/models/pix2text/` 에 SHA-256 검증과 함께 저장된다.
    */
   formulaOcr?: boolean
+  /**
+   * 추출된 이미지를 마크다운에 base64 data URI 로 인라인 (기본 false).
+   *
+   * 활성화 시 `![image](image_001.bmp)` 참조를 `![image](data:image/png;base64,...)` 로
+   * 치환한다. 임베드된 BMP 는 PNG 로 무손실 압축 후 인라인하여 용량을 크게 줄인다.
+   * 별도 이미지 파일 없이 자체 완결형 마크다운이 되어 MCP/AI 에이전트 소비에 적합하다.
+   * (현재 HWP5 경로 지원)
+   */
+  inlineImages?: boolean
 }
 
 // ─── 파싱 경고 ──────────────────────────────────────

--- a/tests/image-transcode.test.ts
+++ b/tests/image-transcode.test.ts
@@ -3,7 +3,7 @@
 import { describe, it } from "node:test"
 import assert from "node:assert/strict"
 import { inflateSync } from "node:zlib"
-import { bmpToPng, inlineImagesIntoMarkdown } from "../src/image/transcode.js"
+import { bmpToPng, inlineImagesIntoMarkdown, MAX_INLINE_MD_BYTES } from "../src/image/transcode.js"
 
 /** 24bpp BI_RGB(bottom-up) BMP 합성 — pixelsTopDown 은 [r,g,b] 배열(행 우선, 0행=최상단) */
 function makeBmp24(width: number, height: number, pixelsTopDown: number[][]): Uint8Array {
@@ -97,6 +97,30 @@ describe("bmpToPng", () => {
     bmp8.writeUInt16LE(8, 28) // biBitCount = 8
     assert.equal(bmpToPng(new Uint8Array(bmp8)), null, "8bpp 미지원")
   })
+
+  it("W×H 가 픽셀 상한(~64MP)을 넘으면 할당 전에 null 을 반환한다", () => {
+    // 54바이트 헤더만 만들고 거대한 폭·높이를 '주장'한다 — 실제 픽셀 데이터는 없다.
+    // 각 변(20000)은 MAX_DIM(0x7fff=32767) 이하이므로 변별 상한은 통과하지만
+    // 곱(4억 픽셀)이 64MP 를 크게 초과 → rgba/raw 할당·deflate 이전에 차단되어야 한다.
+    // (구현이 픽셀 검사를 stride/잘림 검사보다 앞에 두므로, null 은 픽셀 상한에 의한 것이다.)
+    const buf = Buffer.alloc(54)
+    buf[0] = 0x42
+    buf[1] = 0x4d // "BM"
+    buf.writeUInt32LE(54, 10) // bfOffBits
+    buf.writeUInt32LE(40, 14) // biSize (BITMAPINFOHEADER)
+    buf.writeInt32LE(20000, 18) // width  (≤ MAX_DIM)
+    buf.writeInt32LE(20000, 22) // height (≤ MAX_DIM) → 20000×20000 = 4억 픽셀
+    buf.writeUInt16LE(1, 26) // biPlanes
+    buf.writeUInt16LE(24, 28) // biBitCount = 24
+    buf.writeUInt32LE(0, 30) // biCompression = BI_RGB
+    assert.equal(bmpToPng(new Uint8Array(buf)), null, "픽셀 상한 초과는 null")
+  })
+
+  it("MAX_DIM 이하이면서 픽셀 상한 이하인 헤더는 픽셀 검사에서 걸리지 않는다", () => {
+    // 정상 크기 이미지는 픽셀 상한과 무관하게 통과해야 한다 (거짓 양성 방지 회귀).
+    const bmp = makeBmp24(2, 2, [[10, 20, 30], [40, 50, 60], [70, 80, 90], [100, 110, 120]])
+    assert.ok(bmpToPng(bmp), "정상 소형 이미지는 픽셀 상한에 걸리면 안 됨")
+  })
 })
 
 describe("inlineImagesIntoMarkdown", () => {
@@ -128,5 +152,18 @@ describe("inlineImagesIntoMarkdown", () => {
     // base64 가 원본 BMP 바이트와 일치하는지 확인
     const b64 = out.match(/data:image\/bmp;base64,([A-Za-z0-9+/=]+)/)![1]
     assert.deepEqual(new Uint8Array(Buffer.from(b64, "base64")), bmp)
+  })
+})
+
+describe("MAX_INLINE_MD_BYTES (MCP parse_document 인라인 크기 상한)", () => {
+  it("상한은 4MB 이며 바이트 길이 비교가 경계에서 뒤집힌다", () => {
+    // MCP parse_document 는 Buffer.byteLength(markdown) > MAX_INLINE_MD_BYTES 로 폴백 여부를
+    // 결정한다. 상수값과 경계 판정을 고정해 임계 회귀를 막는다. (MCP 서버 진입점은 import
+    // 시 stdio 서버를 기동하므로 핸들러를 직접 부르지 않고, 공유 상수와 판정식을 검증한다.)
+    assert.equal(MAX_INLINE_MD_BYTES, 4 * 1024 * 1024)
+    const atCap = "a".repeat(MAX_INLINE_MD_BYTES)
+    const overCap = "a".repeat(MAX_INLINE_MD_BYTES + 1)
+    assert.ok(!(Buffer.byteLength(atCap, "utf8") > MAX_INLINE_MD_BYTES), "상한 이하는 인라인 유지")
+    assert.ok(Buffer.byteLength(overCap, "utf8") > MAX_INLINE_MD_BYTES, "상한 초과는 비인라인 폴백")
   })
 })

--- a/tests/image-transcode.test.ts
+++ b/tests/image-transcode.test.ts
@@ -1,0 +1,132 @@
+/** BMP→PNG 트랜스코드 + 마크다운 이미지 인라인 단위 테스트 */
+
+import { describe, it } from "node:test"
+import assert from "node:assert/strict"
+import { inflateSync } from "node:zlib"
+import { bmpToPng, inlineImagesIntoMarkdown } from "../src/image/transcode.js"
+
+/** 24bpp BI_RGB(bottom-up) BMP 합성 — pixelsTopDown 은 [r,g,b] 배열(행 우선, 0행=최상단) */
+function makeBmp24(width: number, height: number, pixelsTopDown: number[][]): Uint8Array {
+  const rowStride = (width * 3 + 3) & ~3
+  const pixelDataSize = rowStride * height
+  const fileSize = 54 + pixelDataSize
+  const buf = Buffer.alloc(fileSize)
+  buf[0] = 0x42
+  buf[1] = 0x4d // "BM"
+  buf.writeUInt32LE(fileSize, 2)
+  buf.writeUInt32LE(54, 10) // bfOffBits
+  buf.writeUInt32LE(40, 14) // biSize (BITMAPINFOHEADER)
+  buf.writeInt32LE(width, 18)
+  buf.writeInt32LE(height, 22) // 양수 = bottom-up
+  buf.writeUInt16LE(1, 26) // biPlanes
+  buf.writeUInt16LE(24, 28) // biBitCount
+  buf.writeUInt32LE(0, 30) // biCompression = BI_RGB
+  buf.writeUInt32LE(pixelDataSize, 34)
+  // bottom-up: 저장 첫 행 = 이미지 최하단 행
+  for (let y = 0; y < height; y++) {
+    const imgRow = height - 1 - y
+    let off = 54 + y * rowStride
+    for (let x = 0; x < width; x++) {
+      const [r, g, b] = pixelsTopDown[imgRow * width + x]
+      buf[off] = b // BMP 는 BGR 순
+      buf[off + 1] = g
+      buf[off + 2] = r
+      off += 3
+    }
+  }
+  return new Uint8Array(buf)
+}
+
+/** PNG 에서 IDAT 청크들을 이어붙여 zlib inflate → raw 스캔라인 */
+function inflateIdat(png: Uint8Array): Buffer {
+  const buf = Buffer.from(png)
+  const parts: Buffer[] = []
+  let off = 8 // 시그니처 이후
+  while (off + 8 <= buf.length) {
+    const len = buf.readUInt32BE(off)
+    const type = buf.toString("ascii", off + 4, off + 8)
+    if (type === "IDAT") parts.push(buf.subarray(off + 8, off + 8 + len))
+    if (type === "IEND") break
+    off += 12 + len
+  }
+  return inflateSync(Buffer.concat(parts))
+}
+
+const PNG_SIG = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]
+
+describe("bmpToPng", () => {
+  // 이미지(top-down): [빨강, 초록 / 파랑, 흰색]
+  const RED = [255, 0, 0]
+  const GREEN = [0, 255, 0]
+  const BLUE = [0, 0, 255]
+  const WHITE = [255, 255, 255]
+
+  it("2×2 24bpp bottom-up BMP → 유효 PNG, IDAT 가 기대 RGBA 스캔라인으로 복원된다", () => {
+    const bmp = makeBmp24(2, 2, [RED, GREEN, BLUE, WHITE])
+    const png = bmpToPng(bmp)
+    assert.ok(png, "지원 BMP 는 non-null 이어야 함")
+
+    // PNG 시그니처
+    assert.deepEqual([...png!.subarray(0, 8)], PNG_SIG)
+
+    // IHDR: 2×2, depth 8, colorType 6(RGBA)
+    const b = Buffer.from(png!)
+    assert.equal(b.readUInt32BE(16), 2, "IHDR width")
+    assert.equal(b.readUInt32BE(20), 2, "IHDR height")
+    assert.equal(b[24], 8, "bit depth")
+    assert.equal(b[25], 6, "color type RGBA")
+
+    // 스캔라인 복원 — 각 행 앞에 필터 바이트 0, BGR→RGB + bottom-up 뒤집힘 검증
+    const raw = inflateIdat(png!)
+    assert.equal(raw.length, 2 * (2 * 4 + 1), "raw = height*(width*4 + 1 필터)")
+    // scanline 0 (top): 빨강, 초록
+    assert.equal(raw[0], 0, "필터 바이트 0")
+    assert.deepEqual([...raw.subarray(1, 5)], [255, 0, 0, 255], "(0,0) 빨강 RGBA")
+    assert.deepEqual([...raw.subarray(5, 9)], [0, 255, 0, 255], "(1,0) 초록 RGBA")
+    // scanline 1 (bottom): 파랑, 흰색
+    assert.equal(raw[9], 0, "필터 바이트 0")
+    assert.deepEqual([...raw.subarray(10, 14)], [0, 0, 255, 255], "(0,1) 파랑 RGBA")
+    assert.deepEqual([...raw.subarray(14, 18)], [255, 255, 255, 255], "(1,1) 흰색 RGBA")
+  })
+
+  it("미지원/깨진 입력은 null 을 반환한다", () => {
+    assert.equal(bmpToPng(new Uint8Array([1, 2, 3])), null, "너무 짧음")
+    assert.equal(bmpToPng(new Uint8Array(54)), null, "'BM' 시그니처 아님")
+    // 유효 헤더지만 8bpp(팔레트) → 미지원
+    const bmp8 = Buffer.from(makeBmp24(2, 2, [[0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0]]))
+    bmp8.writeUInt16LE(8, 28) // biBitCount = 8
+    assert.equal(bmpToPng(new Uint8Array(bmp8)), null, "8bpp 미지원")
+  })
+})
+
+describe("inlineImagesIntoMarkdown", () => {
+  const bmp = makeBmp24(2, 2, [[255, 0, 0], [0, 255, 0], [0, 0, 255], [255, 255, 255]])
+  const img = { filename: "foo.bmp", data: bmp, mimeType: "image/bmp" }
+
+  it("![image](foo.bmp) 를 data:image/png data URI 로 치환한다", () => {
+    const out = inlineImagesIntoMarkdown("앞\n![image](foo.bmp)\n뒤", [img])
+    assert.match(out, /!\[image\]\(data:image\/png;base64,[A-Za-z0-9+/=]+\)/)
+    assert.ok(!out.includes("![image](foo.bmp)"), "원본 파일 참조는 남지 않아야 함")
+    assert.ok(out.includes("앞") && out.includes("뒤"), "주변 텍스트는 보존")
+  })
+
+  it("images/ 접두사 참조도 치환한다", () => {
+    const out = inlineImagesIntoMarkdown("![image](images/foo.bmp)", [img])
+    assert.match(out, /!\[image\]\(data:image\/png;base64,/)
+    assert.ok(!out.includes("images/foo.bmp"))
+  })
+
+  it("이미지 참조가 없는 텍스트는 그대로 둔다", () => {
+    const text = "이미지 참조가 전혀 없는 문서\n일반 텍스트"
+    assert.equal(inlineImagesIntoMarkdown(text, [img]), text)
+  })
+
+  it("compress:false 는 트랜스코딩 없이 원본 image/bmp 로 인라인한다", () => {
+    const out = inlineImagesIntoMarkdown("![image](foo.bmp)", [img], { compress: false })
+    assert.match(out, /!\[image\]\(data:image\/bmp;base64,[A-Za-z0-9+/=]+\)/)
+    assert.ok(!out.includes("data:image/png"), "BMP 변환이 일어나면 안 됨")
+    // base64 가 원본 BMP 바이트와 일치하는지 확인
+    const b64 = out.match(/data:image\/bmp;base64,([A-Za-z0-9+/=]+)/)![1]
+    assert.deepEqual(new Uint8Array(Buffer.from(b64, "base64")), bmp)
+  })
+})

--- a/tests/inline-images-cli.test.ts
+++ b/tests/inline-images-cli.test.ts
@@ -1,0 +1,112 @@
+/** --inline-images 비-HWP5 이미지 유실 방지 회귀 (image-1)
+ *
+ * 이미지 인라인은 HWP5 경로(parser.ts)에서만 실제로 일어난다. CLI 가 --inline-images 만
+ * 보고 모든 포맷에서 이미지 저장을 건너뛰면, 비-HWP5(HWPX/DOCX) 문서는 이미지 바이트가
+ * 통째로 유실된다. 수정: 실제 인라인된 경우(fileType==="hwp")에만 저장/접두사를 생략한다.
+ *
+ * 검증 매개체로 DOCX 를 쓴다 — jszip 으로 이미지 1개짜리 최소 DOCX 를 합성해 실제 CLI 를
+ * 돌린다. (DOCX 마크다운은 이미지 참조를 내지 않으므로 여기선 '바이트 유실 없음'을 검증한다.
+ * HWP5 인라인 경로의 참조 치환은 실파일 E2E 로 별도 확인.)
+ */
+
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import { execFileSync } from "node:child_process"
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { fileURLToPath } from "node:url"
+import JSZip from "jszip"
+
+const CLI = fileURLToPath(new URL("../src/cli.ts", import.meta.url))
+
+/** BinData 로 남을 임의 바이트 — 유효 이미지일 필요 없음(파서가 바이트를 그대로 저장) */
+const IMAGE_BYTES = Uint8Array.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 11, 22, 33, 44, 55, 66])
+
+const DOCUMENT_XML = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing">
+  <w:body>
+    <w:p><w:r><w:t>이미지 포함 문서</w:t></w:r></w:p>
+    <w:p><w:r><w:drawing><wp:inline><a:graphic><a:graphicData>
+      <pic:pic xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture">
+        <pic:blipFill><a:blip r:embed="rId1"/></pic:blipFill>
+      </pic:pic>
+    </a:graphicData></a:graphic></wp:inline></w:drawing></w:r></w:p>
+  </w:body>
+</w:document>`
+
+const DOC_RELS = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="media/image1.png"/>
+</Relationships>`
+
+const CONTENT_TYPES = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="png" ContentType="image/png"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+</Types>`
+
+const ROOT_RELS = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rIdDoc" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>`
+
+/** 이미지 1개짜리 최소 DOCX 를 합성해 파일로 쓴다 */
+async function buildImageDocx(path: string): Promise<void> {
+  const zip = new JSZip()
+  zip.file("[Content_Types].xml", CONTENT_TYPES)
+  zip.file("_rels/.rels", ROOT_RELS)
+  zip.file("word/document.xml", DOCUMENT_XML)
+  zip.file("word/_rels/document.xml.rels", DOC_RELS)
+  zip.file("word/media/image1.png", IMAGE_BYTES)
+  const buf = await zip.generateAsync({ type: "nodebuffer" })
+  writeFileSync(path, buf)
+}
+
+test("image-1: --inline-images 로 비-HWP5(DOCX) 변환 시 이미지 바이트가 유실되지 않고 저장된다", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "kordoc-inline-docx-"))
+  try {
+    const docx = join(dir, "imgdoc.docx")
+    await buildImageDocx(docx)
+    const outDir = join(dir, "out")
+
+    execFileSync(
+      process.execPath,
+      ["--import", "tsx", CLI, docx, "--inline-images", "-d", outDir, "--silent"],
+      { stdio: ["ignore", "ignore", "ignore"], timeout: 30000 },
+    )
+
+    // 핵심: 인라인이 실제로 일어나지 않는 포맷이므로 이미지가 파일로 저장되어야 한다(바이트 유실 X)
+    const savedImg = join(outDir, "images", "image_001.png")
+    assert.ok(existsSync(savedImg), "비-HWP5 는 --inline-images 여도 이미지가 저장되어야 함")
+    assert.deepEqual(new Uint8Array(readFileSync(savedImg)), IMAGE_BYTES, "저장된 이미지 바이트가 원본과 일치")
+
+    // 비-HWP5 는 인라인되지 않으므로 마크다운에 data URI 가 새어나오면 안 된다
+    const md = readFileSync(join(outDir, "imgdoc.md"), "utf-8")
+    assert.ok(!md.includes("data:image"), "인라인되지 않은 포맷 출력에 data URI 가 없어야 함")
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test("image-1: --inline-images 없는 레거시 경로도 이미지를 그대로 저장한다(무변화)", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "kordoc-inline-docx-legacy-"))
+  try {
+    const docx = join(dir, "imgdoc.docx")
+    await buildImageDocx(docx)
+    const outDir = join(dir, "out")
+
+    execFileSync(
+      process.execPath,
+      ["--import", "tsx", CLI, docx, "-d", outDir, "--silent"],
+      { stdio: ["ignore", "ignore", "ignore"], timeout: 30000 },
+    )
+
+    const savedImg = join(outDir, "images", "image_001.png")
+    assert.ok(existsSync(savedImg), "레거시 경로도 이미지를 저장해야 함")
+    assert.deepEqual(new Uint8Array(readFileSync(savedImg)), IMAGE_BYTES, "저장된 이미지 바이트가 원본과 일치")
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## 동기

AI 에이전트/MCP 소비 시나리오에서 이미지 처리에 공백이 있습니다: 마크다운 모드는 `![image](image_001.bmp)` 파일 참조를 내보내지만, MCP `parse_document`는 이미지 바이트를 버려 에이전트가 접근할 수 없는 죽은 참조가 남습니다. 게다가 임베드 이미지가 raw BMP(장당 수 MB)라 인라인해도 용량이 큽니다.

## 변경

이미지를 **BMP→PNG 무손실 압축 후 base64 data URI로 인라인**하는 opt-in 기능을 추가합니다. `blocksToMarkdown` 시그니처를 건드리지 않는 마크다운 후처리로 디커플했습니다.

- `src/image/transcode.ts` (신규, 순수 JS·의존성 없음):
  - `bmpToPng()` — 무압축 BMP(24/32bpp, BI_RGB, bottom-up/top-down, 행 패딩) 디코드 → RGBA → PNG 인코드(`node:zlib` deflate + 자체 CRC32). 미지원 변형은 `null` 반환(원본 폴백).
  - `inlineImagesIntoMarkdown()` — `![image](FILENAME)`을 data URI로 치환. `image/bmp`는 PNG로 압축(실측 5.92MB→86.4KB, 약 67배), 실패 시 원본 폴백. 파일명 정규식 이스케이프.
- `ParseOptions.inlineImages`(기본 false) / CLI `--inline-images` / MCP `parse_document`는 자체 완결형 마크다운을 위해 기본 인라인.

## 안전장치

- CLI: 실제 인라인되는 경우(`fileType==="hwp"`)에만 이미지 파일 저장을 생략 — 비-HWP5 포맷의 이미지 유실/죽은 참조 방지.
- MCP: 인라인 마크다운이 `MAX_INLINE_MD_BYTES`(4MB) 초과 시 파일 참조 마크다운으로 폴백 + 안내(에이전트 컨텍스트/전송 오버플로 방지). 폴백은 실제 인라인이 일어난 경우로 한정해 포맷별 후처리(PDF `cleanPdfText` 등) 손실 방지.
- 코덱: `bmpToPng`에 총 픽셀 상한(`MAX_PIXELS=64MP`)을 할당 이전에 검사 — 대형 raw BMP의 메모리/동기 CPU 증폭 차단. dim은 이미 ≤32767로 클램프되어 `width*height` 정수 오버플로 없음.
- 파서: 인라인 호출을 try/catch로 감싸 예외 시 비인라인 마크다운으로 폴백 + `SKIPPED_IMAGE` 경고.

## 테스트 계획

- [x] `npm run build` 성공
- [x] `npm test` — 전체 통과 + 신규 `tests/image-transcode.test.ts`, `tests/inline-images-cli.test.ts`
- [x] 실제 공문서 HWP E2E: `--inline-images` 시 `data:image/png;base64` 인라인·BMP 참조 0·별도 이미지 미저장 / 무플래그 시 기존 파일 참조 동작 유지
- [x] 코덱 검증: 24/32bpp × bottom-up/top-down × 다양한 폭에서 sharp 대조 픽셀 일치, PNG/CRC 적합, 악성/미지원 입력은 throw 없이 null

## 하위 호환

`inlineImages`/`--inline-images` 미지정 시 라이브러리·CLI 기본 동작 불변(파일 참조 + 이미지 저장). 새 npm 의존성 없음(Node 내장만 사용).
