### PR TITLE
fix(hwpx): 중첩 인라인 강조가 별 리터럴·이탤릭 오염으로 깨지던 문제 (#61)

### DIFF
--- a/src/hwpx/md-runs.ts
+++ b/src/hwpx/md-runs.ts
@@ -265,38 +265,7 @@ export function parseInlineMarkdown(text: string): InlineSpan[] {
   // 전처리: ~~취소선~~ → 텍스트만
   text = text.replace(/~~([^~]+)~~/g, "$1")
 
-  const spans: InlineSpan[] = []
-  // 패턴: `code`, ***bolditalic***, **bold**, *italic*, __bold__, _italic_
-  // 언더스코어 강조는 GFM처럼 단어 내부 비활성 (post_id·__init__ 오염 방지, v4.0.5):
-  // 여는 _ 는 앞이 공백/구두점/문두 + 뒤가 비공백, 닫는 _ 는 앞이 비공백 + 뒤가
-  // 공백/구두점/문미일 때만. (?<!_)/(?!_)는 _ run을 원자로 취급(_init_ 부분매칭 방지),
-  // \x00 은 이스케이프 센티널(마스킹된 구두점)이라 경계로 인정. */** 강조는 종전 그대로.
-  const regex = /(`[^`]+`|\*{3}[^*]+\*{3}|\*{2}[^*]+\*{2}|\*[^*]+\*|(?<![^\s\p{P}\p{S}\x00])(?<!_)_{2}(?=\S)[^_]+(?<=\S)_{2}(?!_)(?![^\s\p{P}\p{S}\x00])|(?<![^\s\p{P}\p{S}\x00])(?<!_)_(?=\S)[^_]+(?<=\S)_(?!_)(?![^\s\p{P}\p{S}\x00]))/gu
-  let lastIdx = 0
-
-  for (const match of text.matchAll(regex)) {
-    const idx = match.index!
-    if (idx > lastIdx) {
-      spans.push({ text: text.slice(lastIdx, idx), bold: false, italic: false, code: false })
-    }
-    const raw = match[0]
-    if (raw.startsWith("`")) {
-      spans.push({ text: raw.slice(1, -1), bold: false, italic: false, code: true })
-    } else if (raw.startsWith("***") || raw.startsWith("___")) {
-      spans.push({ text: raw.slice(3, -3), bold: true, italic: true, code: false })
-    } else if (raw.startsWith("**") || raw.startsWith("__")) {
-      spans.push({ text: raw.slice(2, -2), bold: true, italic: false, code: false })
-    } else {
-      spans.push({ text: raw.slice(1, -1), bold: false, italic: true, code: false })
-    }
-    lastIdx = idx + raw.length
-  }
-  if (lastIdx < text.length) {
-    spans.push({ text: text.slice(lastIdx), bold: false, italic: false, code: false })
-  }
-  if (spans.length === 0) {
-    spans.push({ text, bold: false, italic: false, code: false })
-  }
+  const spans = parseSpans(text, 0)
   // 센티널 → 리터럴 복원. 인라인 코드 안은 CommonMark처럼 이스케이프 처리가
   // 없으므로 백슬래시까지 원문 그대로 되살린다.
   for (const span of spans) {
@@ -305,6 +274,59 @@ export function parseInlineMarkdown(text: string): InlineSpan[] {
       const c = literals[+i] ?? ""
       return span.code ? "\\" + c : c
     })
+  }
+  return spans
+}
+
+// 패턴: `code`, ***bolditalic***, **bold**, *italic*, __bold__, _italic_
+// **/***/* 는 안쪽에 더 짧은 별 run 을 허용 — **굵게 *기울임*** 같은 중첩 강조가
+// 매칭에서 통째로 탈락해 별 하나짜리 두 개로 오인되던 것을 방지. 중첩 내용은
+// parseSpans 재귀로 분해해 겉 강조 플래그를 OR 한다.
+// 언더스코어 강조는 GFM처럼 단어 내부 비활성 (post_id·__init__ 오염 방지, v4.0.5):
+// 여는 _ 는 앞이 공백/구두점/문두 + 뒤가 비공백, 닫는 _ 는 앞이 비공백 + 뒤가
+// 공백/구두점/문미일 때만. (?<!_)/(?!_)는 _ run을 원자로 취급(_init_ 부분매칭 방지),
+// \x00 은 이스케이프 센티널(마스킹된 구두점)이라 경계로 인정.
+const INLINE_REGEX = /(`[^`]+`|\*{3}(?:[^*]|\*(?!\*\*))+\*{3}|\*{2}(?:[^*]|\*(?!\*))+\*{2}|\*(?:[^*]|\*{2}(?:[^*]|\*(?!\*))+\*{2})+\*|(?<![^\s\p{P}\p{S}\x00])(?<!_)_{2}(?=\S)[^_]+(?<=\S)_{2}(?!_)(?![^\s\p{P}\p{S}\x00])|(?<![^\s\p{P}\p{S}\x00])(?<!_)_(?=\S)[^_]+(?<=\S)_(?!_)(?![^\s\p{P}\p{S}\x00]))/gu
+
+/** 강조 중첩은 한 단계씩 재귀로 벗긴다 — depth 는 병리적 입력 폭주 방지용 상한 */
+function parseSpans(text: string, depth: number): InlineSpan[] {
+  const spans: InlineSpan[] = []
+  let lastIdx = 0
+
+  for (const match of text.matchAll(INLINE_REGEX)) {
+    const idx = match.index!
+    if (idx > lastIdx) {
+      spans.push({ text: text.slice(lastIdx, idx), bold: false, italic: false, code: false })
+    }
+    const raw = match[0]
+    if (raw.startsWith("`")) {
+      spans.push({ text: raw.slice(1, -1), bold: false, italic: false, code: true })
+    } else {
+      let inner: string
+      let bold = false
+      let italic = false
+      if (raw.startsWith("***") || raw.startsWith("___")) {
+        inner = raw.slice(3, -3); bold = true; italic = true
+      } else if (raw.startsWith("**") || raw.startsWith("__")) {
+        inner = raw.slice(2, -2); bold = true
+      } else {
+        inner = raw.slice(1, -1); italic = true
+      }
+      if (depth < 3 && /[`*_]/.test(inner)) {
+        for (const child of parseSpans(inner, depth + 1)) {
+          spans.push(child.code ? child : { ...child, bold: child.bold || bold, italic: child.italic || italic })
+        }
+      } else {
+        spans.push({ text: inner, bold, italic, code: false })
+      }
+    }
+    lastIdx = idx + raw.length
+  }
+  if (lastIdx < text.length) {
+    spans.push({ text: text.slice(lastIdx), bold: false, italic: false, code: false })
+  }
+  if (spans.length === 0) {
+    spans.push({ text, bold: false, italic: false, code: false })
   }
   return spans
 }

--- a/tests/md-runs-edge.test.ts
+++ b/tests/md-runs-edge.test.ts
@@ -114,3 +114,53 @@ describe("v4.0.5 언더스코어 단어내부 강조 회귀", () => {
     assert.deepEqual(spans.filter(s => s.bold).map(s => s.text), ["볼드"])
   })
 })
+
+describe("중첩 강조 회귀 — **a *b* c** 가 별 리터럴로 오염되던 문제", () => {
+  const flags = (s: { bold: boolean; italic: boolean; code: boolean }) =>
+    `${s.bold ? "B" : ""}${s.italic ? "I" : ""}${s.code ? "C" : ""}`
+
+  it("굵게 안 기울임: **굵게 *기울임* 다시**", () => {
+    const spans = parseInlineMarkdown("**굵게 *기울임* 다시**")
+    assert.deepEqual(spans.map(s => [s.text, flags(s)]), [
+      ["굵게 ", "B"], ["기울임", "BI"], [" 다시", "B"],
+    ])
+  })
+
+  it("기울임 안 굵게: *기울임 **굵게** 다시*", () => {
+    const spans = parseInlineMarkdown("*기울임 **굵게** 다시*")
+    assert.deepEqual(spans.map(s => [s.text, flags(s)]), [
+      ["기울임 ", "I"], ["굵게", "BI"], [" 다시", "I"],
+    ])
+  })
+
+  it("별 강조 안 언더스코어 (교차 중첩): **a _u_ b** · __a *i* b__", () => {
+    assert.deepEqual(parseInlineMarkdown("**a _u_ b**").map(s => [s.text, flags(s)]), [
+      ["a ", "B"], ["u", "BI"], [" b", "B"],
+    ])
+    assert.deepEqual(parseInlineMarkdown("__a *i* b__").map(s => [s.text, flags(s)]), [
+      ["a ", "B"], ["i", "BI"], [" b", "B"],
+    ])
+  })
+
+  it("굵게 안 인라인 코드는 코드 서식 유지: **`code` 안**", () => {
+    assert.deepEqual(parseInlineMarkdown("**`code` 안**").map(s => [s.text, flags(s)]), [
+      ["code", "C"], [" 안", "B"],
+    ])
+  })
+
+  it("기존 단독 강조·***셋다***·이스케이프 불변", () => {
+    assert.deepEqual(parseInlineMarkdown("***셋다***").map(s => [s.text, flags(s)]), [["셋다", "BI"]])
+    assert.deepEqual(parseInlineMarkdown("평문 **굵게** 뒤 *기울임*").map(s => [s.text, flags(s)]), [
+      ["평문 ", ""], ["굵게", "B"], [" 뒤 ", ""], ["기울임", "I"],
+    ])
+    assert.deepEqual(parseInlineMarkdown("\\*리터럴\\* **굵게**").map(s => [s.text, flags(s)]), [
+      ["*리터럴* ", ""], ["굵게", "B"],
+    ])
+  })
+
+  it("미닫힘 굵게는 종전 폴백 그대로 (파싱 폭주 없음)", () => {
+    const spans = parseInlineMarkdown("**미닫힘 *기울임*")
+    assert.equal(spans.map(s => s.text).join(""), "*미닫힘 기울임*")
+    assert.ok(spans.every(s => !s.bold))
+  })
+})


### PR DESCRIPTION
Closes #61

## 무엇을

중첩 인라인 강조(`**a *b* c**`, `*a **b** c*`, `**a _u_ b**`, 굵게 안 `` `code` ``)가 별 리터럴 노출·굵게 소실·서식 역전으로 깨지던 문제를 수정합니다.

## 어떻게

`src/hwpx/md-runs.ts`:

1. **정규식 확장** — `*`/`**`/`***` 대안이 안쪽의 더 짧은 별 run 을 허용하도록 변경 (`\*{2}(?:[^*]|\*(?!\*))+\*{2}` 등). 언더스코어 대안은 기존 그대로입니다.
2. **재귀 분해** — 매칭된 강조 내부에 강조 문자가 남아 있으면 `parseSpans` 재귀(병리적 입력 방지 상한 3)로 분해해 겉 강조 플래그를 OR 합니다. 안쪽 인라인 코드는 코드 서식을 유지합니다.
3. 이스케이프 센티널 마스킹·복원은 최상위 `parseInlineMarkdown` 한 곳에서만 수행하므로 재귀와 충돌하지 않습니다.

기존 `CHAR_BOLD_ITALIC` charPr 매핑(`***a***` 용으로 이미 존재)을 그대로 타기 때문에 XML 스키마나 렌더 경로 변경은 없습니다.

## 동작 불변 확인

- 단독 `**굵게**`/`*기울임*`/`***셋다***`, 이스케이프 `\*`, snake_case·`__init__` 비활성, 미닫힘 `**` 폴백 — 전부 종전 span 출력과 동일
- 기존 테스트 1,382개 무수정 통과, 회귀 테스트 6개 추가 (`tests/md-runs-edge.test.ts`)

## 전후 비교 (공문서 프리셋 `보고서` → kordoc render)

같은 마크다운, 같은 렌더러 — 차이는 이 PR 커밋 하나입니다. 재현 마크다운·hwpx 원본: [demo/nested-emphasis-assets](https://github.com/leeyudok/kordoc/tree/demo/nested-emphasis-assets)

| 수정 전 (v4.4.0) | 수정 후 |
|---|---|
| ![before](https://raw.githubusercontent.com/leeyudok/kordoc/refs/heads/demo/nested-emphasis-assets/before.png) | ![after](https://raw.githubusercontent.com/leeyudok/kordoc/refs/heads/demo/nested-emphasis-assets/after.png) |

참고: `bench/corpus` 게이트는 코퍼스가 로컬에 없어 돌리지 못했습니다. `npm test` 전체 통과 기준입니다.
